### PR TITLE
Add rust-analyzer clippy end-to-end test

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -400,6 +400,7 @@ tasks:
       - "//tools/rust_analyzer:discover_bazel_rust_project"
       - "//test/rust_analyzer:rust_analyzer_test"
       - "//test/rust_analyzer:partial_failure_test"
+      - "//test/rust_analyzer:flycheck_clippy_test"
   ide_integration_tests_macos:
     name: IDE VSCode Tests
     platform: macos_arm64
@@ -410,6 +411,7 @@ tasks:
       - "//tools/rust_analyzer:discover_bazel_rust_project"
       - "//test/rust_analyzer:rust_analyzer_test"
       - "//test/rust_analyzer:partial_failure_test"
+      - "//test/rust_analyzer:flycheck_clippy_test"
   ide_integration_tests_windows:
     name: IDE VSCode Tests
     platform: windows

--- a/docs/src/rust_analyzer.md
+++ b/docs/src/rust_analyzer.md
@@ -72,7 +72,6 @@ Re-runnable at any time. Global flags work on any subcommand.
 
 | Flag | Effect |
 |---|---|
-| `--workspace <path>` | Workspace root. Defaults to `$BUILD_WORKSPACE_DIRECTORY` (set by `bazel run`). |
 | `--skip-proc-macro-server` | Don't manage the proc-macro key. |
 | `--skip-rustfmt` | Don't manage the formatter key (use host rustfmt). |
 | `--per-package-workspaces` / `--no-per-package-workspaces` | Opt this developer in/out of per-package workspace splitting (see below). |

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -283,7 +283,7 @@ def _clippy_aspect_impl(target, ctx):
         crate_info = crate_info,
         config = ctx.file._config,
         output = clippy_out,
-        cap_at_warnings = clippy_out != None,  # If we're capturing output, we want the build to continue.
+        cap_at_warnings = clippy_out != None or clippy_diagnostics != None,  # Collecting output for a tool -> cap so the build continues.
         success_marker = clippy_success_marker,
         extra_clippy_flags = clippy_flags,
         error_format = error_format,

--- a/test/rust_analyzer/BUILD.bazel
+++ b/test/rust_analyzer/BUILD.bazel
@@ -10,3 +10,8 @@ sh_binary(
     name = "partial_failure_test",
     srcs = ["partial_failure_test_runner.sh"],
 )
+
+sh_binary(
+    name = "flycheck_clippy_test",
+    srcs = ["flycheck_clippy_test_runner.sh"],
+)

--- a/test/rust_analyzer/flycheck_clippy_test_runner.sh
+++ b/test/rust_analyzer/flycheck_clippy_test_runner.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# End-to-end test for the setup → discover → flycheck pipeline with
+# clippy enabled. Stands up a workspace with a `rust_library` whose
+# source triggers a clippy-only lint, runs `setup --clippy`, runs
+# discovery, invokes flycheck the way rust-analyzer would on save,
+# and checks that a clippy diagnostic ends up in flycheck's output.
+#
+# Regression coverage for two contract failures:
+#   1. `assemble_rust_project` baking a flag into the runnable command
+#      that flycheck's CLI doesn't accept — the bug pattern that shipped
+#      the initial clippy support: `--clippy` was prepended to the
+#      runnable but flycheck's Args struct never learned about it.
+#   2. `bin/flycheck.rs` silently ignoring the per-user `clippy=true`
+#      preference in `user_config.json` — the fallback path that keeps
+#      the runnable command byte-identical across users.
+
+set -euo pipefail
+
+if [[ -z "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then
+    >&2 echo "This script should be run under Bazel"
+    exit 1
+fi
+
+workspace="$(mktemp -d -t rules_rust_ra_flycheck_clippy-XXXXXXXXXX)"
+
+cat >"${workspace}/MODULE.bazel" <<EOF
+module(name = "rules_rust_ra_flycheck_clippy", version = "0.0.0")
+bazel_dep(name = "rules_rust", version = "0.0.0")
+local_path_override(
+    module_name = "rules_rust",
+    path = "${BUILD_WORKSPACE_DIRECTORY}",
+)
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+use_repo(rust, "rust_toolchains")
+register_toolchains("@rust_toolchains//:all")
+EOF
+
+if [[ -f "${BUILD_WORKSPACE_DIRECTORY}/.bazelversion" ]]; then
+    cp "${BUILD_WORKSPACE_DIRECTORY}/.bazelversion" "${workspace}/.bazelversion"
+fi
+
+# `assert!(true)` triggers `clippy::assertions_on_constants` (warn by
+# default) without triggering any rustc warning — a clean signal that a
+# clippy diagnostic reached flycheck's output.
+cat >"${workspace}/lib.rs" <<'EOF'
+pub fn check_it() {
+    assert!(true);
+}
+EOF
+
+cat >"${workspace}/BUILD.bazel" <<'EOF'
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+rust_library(
+    name = "clippy_target",
+    srcs = ["lib.rs"],
+    edition = "2021",
+)
+EOF
+
+cd "${workspace}"
+
+fail() {
+    >&2 echo "FAIL: $1"
+    for f in discovery.json flycheck.out flycheck.err; do
+        if [[ -f "${f}" ]]; then
+            >&2 echo "--- ${f} ---"
+            >&2 cat "${f}"
+        fi
+    done
+    exit 1
+}
+
+echo "Installing setup binaries with --clippy..."
+bazel run @rules_rust//tools/rust_analyzer:setup -- --clippy neovim >/dev/null
+
+launcher_dir="${workspace}/.rules_rust_analyzer"
+[[ -f "${launcher_dir}/flycheck.exe" ]] || fail "flycheck.exe not installed at ${launcher_dir}"
+[[ -f "${launcher_dir}/user_config.json" ]] || fail "user_config.json not written by setup"
+grep -q '"clippy": *true' "${launcher_dir}/user_config.json" || \
+    fail "user_config.json did not record clippy=true"
+
+# Discover self-locates via `dirname(current_exe())` when invoked from
+# an install directory, but here we're running the bazel-bin copy —
+# publish the launcher dir explicitly so `flycheck_launcher_path`
+# resolves to the install we just wrote.
+export RULES_RUST_RA_LAUNCHER_DIR="${launcher_dir}"
+
+echo "Running discovery..."
+bazel run @rules_rust//tools/rust_analyzer:discover_bazel_rust_project >discovery.json || true
+
+# Regression #1: discovery must NOT bake `--clippy` (or any per-user
+# preference) into the runnable command. The runnable is shared across
+# developers and must stay byte-identical regardless of who ran discover.
+if grep -q '"--clippy"' discovery.json; then
+    fail "'--clippy' leaked into the discovery output — the runnable command should be user-agnostic"
+fi
+
+grep -q '"kind":"finished"' discovery.json || fail "discovery did not finish"
+
+# Invoke flycheck as rust-analyzer would on save. The runnable's exact
+# arg shape is verified by the `flycheck_runnable_uses_positional_args_only`
+# unit test in `rust_project.rs`; this test just needs the two
+# positional args in place so we can prove the user_config → aspect
+# path fires. `BUILD_WORKSPACE_DIRECTORY` is overridden because the
+# outer `bazel run` for this test leaks its own value (this repo's
+# root).
+echo "Invoking flycheck as rust-analyzer would..."
+BUILD_WORKSPACE_DIRECTORY="${workspace}" \
+    "${launcher_dir}/flycheck.exe" "//:clippy_target" "${workspace}/lib.rs" \
+    >flycheck.out 2>flycheck.err || true
+
+# Regression #2: with clippy enabled in user_config, flycheck must
+# actually invoke the clippy aspect (proven by the lint firing). The
+# diagnostic surfaces via stdout (JSON from `.clippy.diagnostics` when
+# the action succeeds) or stderr (bazel's rendered output when
+# `-D warnings` fails the build hard) — check both.
+if ! grep -q "assertions_on_constants\|assertions-on-constants" flycheck.out flycheck.err; then
+    fail "no clippy diagnostic in flycheck output — the user_config → aspect path is broken"
+fi
+
+echo "PASS: discovery emitted a user-agnostic runnable that flycheck accepts, and clippy diagnostics reached the output"
+
+bazel clean --expunge --async >/dev/null 2>&1 || true
+cd /
+rm -rf "${workspace}"

--- a/tools/rust_analyzer/bin/discover_rust_project.rs
+++ b/tools/rust_analyzer/bin/discover_rust_project.rs
@@ -42,12 +42,9 @@ fn project_discovery() -> anyhow::Result<DiscoverProject<'static>> {
         rust_analyzer_argument,
     } = Config::parse()?;
 
-    // Per-user, per-workspace preferences. Rendered
-    // `discoverConfig.command` is intentionally identical for every
-    // developer — clippy and per-package-workspaces toggles live in
-    // `<launcher_dir>/user_config.json` (see `user_config.rs`).
-    // Clippy is consulted per-save inside `bin/flycheck.rs` and does
-    // not need to be threaded through discovery.
+    // Per-user toggles live in `<launcher_dir>/user_config.json` so
+    // the rendered `discoverConfig.command` stays identical for every
+    // developer.
     let user = user_config::load(&install_dir()?);
     log::info!(
         "user config: per_package_workspaces={}",
@@ -56,12 +53,9 @@ fn project_discovery() -> anyhow::Result<DiscoverProject<'static>> {
 
     log::info!("got rust-analyzer argument: {rust_analyzer_argument:?}");
 
-    // When per-package-workspaces is off, the rust-analyzer-provided
-    // arg is discarded and we always emit the whole-workspace project.
-    // The rendered `{arg}` template stays in the discover command
-    // regardless — this keeps the shared settings byte-identical, at
-    // the cost of an occasional cache-hit-only re-invocation of
-    // discover on file open.
+    // Whole-workspace mode ignores the RA-provided arg — the `{arg}`
+    // template stays in the command for shape-parity with the
+    // per-package case.
     let ra_arg = if user.per_package_workspaces {
         match rust_analyzer_argument {
             Some(ra_arg) => ra_arg,
@@ -71,14 +65,31 @@ fn project_discovery() -> anyhow::Result<DiscoverProject<'static>> {
         RustAnalyzerArg::Buildfile(find_workspace_root_file(&workspace)?)
     };
 
-    let rules_rust_name = env!("ASPECT_REPOSITORY");
+    // `ASPECT_REPOSITORY` is empty when discover was built inside
+    // rules_rust itself — that produces `//rust:defs.bzl`, only valid
+    // when the outer bazel invocation is IN rules_rust. Fall back to
+    // the apparent `@rules_rust` name so a discover binary shipped to
+    // a downstream workspace still resolves the aspect.
+    let rules_rust_name = match env!("ASPECT_REPOSITORY") {
+        "" => "@rules_rust",
+        other => other,
+    };
 
     log::info!("resolved rust-analyzer argument: {ra_arg:?}");
 
-    let (buildfile, targets) = ra_arg.into_target_details(&workspace)?;
+    let (per_call_buildfile, targets) = ra_arg.into_target_details(&workspace)?;
 
-    log::debug!("got buildfile: {buildfile}");
-    log::debug!("got targets: {targets}");
+    // RA's `add_discovered_project_from_command` dedupes by
+    // buildfile — a match UPDATES, a new one PUSHES. Always report
+    // the workspace-root buildfile so per-package calls update the
+    // single Bazel-project entry instead of accumulating (each new
+    // workspace costs a proc-macro server, ~200-800 MB).
+    let buildfile = find_workspace_root_file(&workspace)?;
+
+    log::debug!(
+        "reporting workspace-root buildfile {buildfile} \
+         (per-call resolved to {per_call_buildfile}, targets {targets})"
+    );
 
     // Use the generated files to print the rust-project.json.
     let project = generate_rust_project(
@@ -106,9 +117,8 @@ where
 }
 
 /// Publish per-install state via env vars the library reads.
-/// `setup` copies this binary into the launcher dir, so
-/// `dirname(current_exe())` IS that dir. Pre-set values win so users
-/// and tests can override.
+/// `dirname(current_exe())` is the launcher dir (setup copies this
+/// binary into it). Pre-set values win so users and tests can override.
 fn self_locate_config() -> anyhow::Result<()> {
     let launcher_dir = gen_rust_project_lib::install_dir()?;
     for (name, path) in [

--- a/tools/rust_analyzer/bin/discover_rust_project.rs
+++ b/tools/rust_analyzer/bin/discover_rust_project.rs
@@ -46,10 +46,11 @@ fn project_discovery() -> anyhow::Result<DiscoverProject<'static>> {
     // `discoverConfig.command` is intentionally identical for every
     // developer — clippy and per-package-workspaces toggles live in
     // `<launcher_dir>/user_config.json` (see `user_config.rs`).
+    // Clippy is consulted per-save inside `bin/flycheck.rs` and does
+    // not need to be threaded through discovery.
     let user = user_config::load(&install_dir()?);
     log::info!(
-        "user config: clippy={} per_package_workspaces={}",
-        user.clippy,
+        "user config: per_package_workspaces={}",
         user.per_package_workspaces
     );
 
@@ -89,7 +90,6 @@ fn project_discovery() -> anyhow::Result<DiscoverProject<'static>> {
         &bazel_args,
         rules_rust_name,
         &[targets],
-        user.clippy,
     )?;
 
     Ok(DiscoverProject::Finished { buildfile, project })

--- a/tools/rust_analyzer/bin/flycheck.rs
+++ b/tools/rust_analyzer/bin/flycheck.rs
@@ -48,9 +48,7 @@ struct Args {
     bazel: Utf8PathBuf,
 
     /// Bazel `--output_user_root` for the flycheck server. Overrides
-    /// the default (`<install_dir>/output_user_root`, derived from
-    /// `current_exe()`). Useful on Windows where MAX_PATH limits make
-    /// the in-launcher-dir default impractical.
+    /// the default (see [`default_output_user_root`]).
     #[clap(long)]
     output_user_root: Option<Utf8PathBuf>,
 }
@@ -75,23 +73,28 @@ fn run() -> Result<u8> {
     let bep_path = temp_dir.join(format!("flycheck_bep_{}.json", std::process::id()));
     let _bep_cleanup = scopeguard(bep_path.clone());
 
-    // Dedicated `--output_user_root` for the inner `bazel build` so
-    // its `--error_format=json` / `--rustc_output_diagnostics=true`
-    // don't thrash the user's primary Bazel server's analysis cache.
-    // CLI override exists for Windows MAX_PATH cases where the
-    // sibling default is too long.
-    let output_user_root = match args.output_user_root.clone() {
-        Some(p) => p,
-        None => gen_rust_project_lib::install_dir()?.join("output_user_root"),
-    };
-    std::fs::create_dir_all(&output_user_root)
-        .with_context(|| format!("creating output_user_root {output_user_root}"))?;
-
     // Per-user preferences live in `<launcher_dir>/user_config.json`.
     // Clippy mode is a per-user opt-in there — the shared discover
     // command doesn't decide it — so we consult the config on every
     // save rather than baking the choice into flycheck's argv.
     let user = user_config::load(&install_dir()?);
+
+    // Dedicated `--output_user_root` for the inner `bazel build` so
+    // its `--error_format=json` / `--rustc_output_diagnostics=true`
+    // don't thrash the user's primary Bazel server's analysis cache.
+    // Precedence: CLI flag > user_config > platform default. The
+    // default lives next to Bazel's own output roots (~/.cache/bazel
+    // on Linux) — not inside the workspace, which Bazel 8+ rejects
+    // for repo_contents_cache.
+    let output_user_root = match args.output_user_root.clone() {
+        Some(p) => p,
+        None => match user.output_user_root.clone() {
+            Some(p) => p,
+            None => default_output_user_root(&workspace)?,
+        },
+    };
+    std::fs::create_dir_all(&output_user_root)
+        .with_context(|| format!("creating output_user_root {output_user_root}"))?;
 
     // Assemble the bazel command. Clippy mode adds the aspect and
     // its diagnostics output group on top of the base build flags.
@@ -252,6 +255,53 @@ fn workspace_dir() -> Result<Utf8PathBuf> {
     }
     let cwd = env::current_dir().context("current_dir")?;
     Utf8PathBuf::try_from(cwd).context("current_dir was not valid UTF-8")
+}
+
+/// Default location for flycheck's dedicated `--output_user_root`,
+/// sitting next to Bazel's own user cache root
+/// (`~/.cache/bazel/_bazel_<user>/…` on Linux, `~/Library/Caches/bazel/…`
+/// on macOS). Living outside the workspace matters on Bazel 8+, which
+/// errors when a repo_contents_cache falls inside the main repo — the
+/// old default (`<launcher_dir>/output_user_root`) always did.
+///
+/// A per-workspace subdirectory (hashed workspace path) keeps two
+/// projects from sharing a flycheck server.
+fn default_output_user_root(workspace: &Utf8Path) -> Result<Utf8PathBuf> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    workspace.as_str().hash(&mut hasher);
+    let workspace_hash = format!("{:016x}", hasher.finish());
+
+    let cache_root = user_cache_dir()?.join("bazel").join("rules_rust_flycheck");
+    Ok(cache_root.join(workspace_hash))
+}
+
+/// Best-effort platform cache dir. Uses `$XDG_CACHE_HOME` when set;
+/// otherwise `~/.cache` on Linux, `~/Library/Caches` on macOS,
+/// `%LOCALAPPDATA%` on Windows.
+fn user_cache_dir() -> Result<Utf8PathBuf> {
+    if let Ok(dir) = env::var("XDG_CACHE_HOME") {
+        if !dir.is_empty() {
+            return Ok(Utf8PathBuf::from(dir));
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let home = env::var("HOME").context("HOME not set")?;
+        Ok(Utf8PathBuf::from(home).join("Library").join("Caches"))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let dir = env::var("LOCALAPPDATA").context("LOCALAPPDATA not set")?;
+        Ok(Utf8PathBuf::from(dir))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let home = env::var("HOME").context("HOME not set")?;
+        Ok(Utf8PathBuf::from(home).join(".cache"))
+    }
 }
 
 /// Query `bazel info execution_root` against the flycheck server (same

--- a/tools/rust_analyzer/bin/flycheck.rs
+++ b/tools/rust_analyzer/bin/flycheck.rs
@@ -28,7 +28,8 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use gen_rust_project_lib::{
-    bep, install_dir, user_config, ToolchainInfoSidecar, TOOLCHAIN_INFO_SIDECAR,
+    bazel_command, bazel_info, bep, flycheck_output_base, install_dir, user_config, BazelInfo,
+    ToolchainInfoSidecar, TOOLCHAIN_INFO_SIDECAR,
 };
 use serde_json::Value;
 
@@ -58,10 +59,10 @@ struct Args {
     #[clap(long, default_value = "bazel")]
     bazel: Utf8PathBuf,
 
-    /// Bazel `--output_user_root` for the flycheck server. Overrides
-    /// the default (see [`default_output_user_root`]).
+    /// Bazel `--output_base` for the flycheck server. Overrides the
+    /// default derivation (see [`derive_output_base`]).
     #[clap(long)]
-    output_user_root: Option<Utf8PathBuf>,
+    output_base: Option<Utf8PathBuf>,
 }
 
 fn main() -> ExitCode {
@@ -100,29 +101,20 @@ fn run() -> Result<u8> {
 
     let user = user_config::load(&launcher_dir);
 
-    // Dedicated `--output_user_root` for the inner `bazel build` so
-    // its `--error_format=json` doesn't thrash the primary Bazel
-    // server's analysis cache. Precedence: CLI > user_config > default.
-    let output_user_root = match args.output_user_root.clone() {
+    // Dedicated `--output_base` for the inner `bazel build` so its
+    // `--error_format=json` doesn't thrash the primary Bazel server's
+    // analysis cache. Precedence: CLI > user_config > sidecar `_rra`
+    // > setup-populated `BazelInfo` cache > slow `bazel info` fallback
+    // against the outer server.
+    let output_base = match args.output_base.or(user.output_base) {
         Some(p) => p,
-        None => match user.output_user_root.clone() {
-            Some(p) => p,
-            None => default_output_user_root(&workspace)?,
-        },
+        None => derive_output_base(&launcher_dir, &args.bazel, &workspace, sidecar.as_ref())?,
     };
-    std::fs::create_dir_all(&output_user_root)
-        .with_context(|| format!("creating output_user_root {output_user_root}"))?;
+    std::fs::create_dir_all(&output_base)
+        .with_context(|| format!("creating output_base {output_base}"))?;
 
-    let mut cmd = Command::new(args.bazel.as_str());
-    cmd.current_dir(&workspace)
-        // Clear env vars leaked from the outer `bazel run` so the
-        // nested client rediscovers the workspace from cwd.
-        .env_remove("BAZELISK_SKIP_WRAPPER")
-        .env_remove("BUILD_WORKING_DIRECTORY")
-        .env_remove("BUILD_WORKSPACE_DIRECTORY")
-        // `--output_user_root` is a STARTUP option, must precede `build`.
-        .arg(format!("--output_user_root={output_user_root}"))
-        .arg("build")
+    let mut cmd = bazel_command(&args.bazel, Some(&workspace), Some(&output_base));
+    cmd.arg("build")
         .arg(&label)
         // Flags below use the apparent `@rules_rust` name (not a
         // compile-time `ASPECT_REPOSITORY`) — `ASPECT_REPOSITORY`
@@ -139,10 +131,17 @@ fn run() -> Result<u8> {
         .arg("--keep_going")
         .arg(format!("--build_event_json_file={bep_path}"));
     if user.clippy {
+        // `clippy_error_format=json` is separate from `error_format`
+        // (which only covers rustc). Without it the aspect writes
+        // rendered ANSI to `.clippy.diagnostics`, our JSON parser
+        // skips every line, and RA sees zero diagnostics for
+        // clippy-flagged bugs.
+        //
         // `clippy_output_diagnostics=true` gates the aspect writing
-        // JSON to the declared `.clippy.diagnostics` file (vs a
-        // marker), exposed via the `clippy_output` group.
+        // to the declared `.clippy.diagnostics` file (vs a marker),
+        // exposed via the `clippy_output` group.
         cmd.arg("--aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect")
+            .arg("--@rules_rust//rust/settings:clippy_error_format=json")
             .arg("--@rules_rust//rust/settings:clippy_output_diagnostics=true")
             .arg(format!("--output_groups=+{}", bep::CLIPPY_OUTPUT_GROUP));
     }
@@ -163,8 +162,11 @@ fn run() -> Result<u8> {
         // not stderr, when `clippy_output_diagnostics=true`.
         //
         // `parse_output_group_paths` needs flycheck's OWN Bazel exec
-        // root to resolve BEP-relative paths (rules_rust#4130).
-        match bazel_info_execution_root(&args.bazel, &output_user_root)
+        // root to resolve BEP-relative paths (rules_rust#4130). Setup
+        // pre-populates the cache, so steady-state saves incur zero
+        // extra bazel calls; only a stale/missing cache pays the
+        // `bazel info` cost.
+        match cached_execution_root(&launcher_dir, &args.bazel, &workspace, &output_base)
             .and_then(|er| bep::parse_output_group_paths(&bep_path, bep::CLIPPY_OUTPUT_GROUP, &er))
         {
             Ok(paths) => diagnostic_files.extend(paths),
@@ -207,8 +209,14 @@ fn load_toolchain_info(launcher_dir: &Utf8Path) -> Option<ToolchainInfoSidecar> 
 /// (rustc emits them relative to the exec root; RA otherwise resolves
 /// them against the saved file's directory and produces nonsense).
 ///
-/// Non-JSON lines (sandbox warnings, env dumps) pass through so we
-/// don't silently swallow an unrecognized format.
+/// Only diagnostics with at least one primary span are forwarded.
+/// Artifact events, summary lines like "aborting due to N errors",
+/// and other non-actionable JSON are dropped — RA's flycheck actor
+/// flips `diagnostics_received` off `NotYet` for anything that parses
+/// as a `Diagnostic`, and once off `NotYet` the on-finish workspace
+/// clear no longer fires. Filtering to real add-worthy diagnostics
+/// keeps `NotYet` correct so a fix that removes ALL diagnostics
+/// clears the stale ones on the next save.
 fn emit_diagnostics(
     files: &[Utf8PathBuf],
     workspace: &Utf8Path,
@@ -229,24 +237,44 @@ fn emit_diagnostics(
             if !trimmed.starts_with('{') {
                 continue;
             }
-            match serde_json::from_str::<Value>(trimmed) {
-                Ok(mut value) => {
-                    rewrite_file_names(&mut value, workspace, sysroot_src);
-                    serde_json::to_writer(&mut out, &value)
-                        .context("writing rewritten rustc JSON to stdout")?;
-                    out.write_all(b"\n").context("writing newline to stdout")?;
-                }
-                Err(_) => {
-                    // Not JSON — pass through unmodified.
-                    out.write_all(line.as_bytes())
-                        .context("passing through non-JSON line to stdout")?;
-                    out.write_all(b"\n").context("writing newline to stdout")?;
-                }
+            let Ok(mut value) = serde_json::from_str::<Value>(trimmed) else {
+                continue;
+            };
+            if !is_actionable_diagnostic(&value) {
+                continue;
             }
+            rewrite_file_names(&mut value, workspace, sysroot_src);
+            serde_json::to_writer(&mut out, &value)
+                .context("writing rewritten rustc JSON to stdout")?;
+            out.write_all(b"\n").context("writing newline to stdout")?;
         }
     }
     out.flush().context("flushing stdout")?;
     Ok(())
+}
+
+/// A message is add-worthy iff it's a rustc `Diagnostic` (or the
+/// cargo `compiler-message` wrapper of one) AND has at least one
+/// primary span — the only shape RA renders as an editor squiggle.
+fn is_actionable_diagnostic(value: &Value) -> bool {
+    let diag = match value.get("$message_type").and_then(Value::as_str) {
+        Some("diagnostic") => value,
+        _ => match value.get("reason").and_then(Value::as_str) {
+            Some("compiler-message") => match value.get("message") {
+                Some(m) => m,
+                None => return false,
+            },
+            _ => return false,
+        },
+    };
+    diag.get("spans")
+        .and_then(Value::as_array)
+        .map(|spans| {
+            spans
+                .iter()
+                .any(|s| s.get("is_primary").and_then(Value::as_bool) == Some(true))
+        })
+        .unwrap_or(false)
 }
 
 /// Replace `/rustc/<40 hex>/library/` in `input` with `<sysroot_src>/`.
@@ -341,47 +369,75 @@ fn workspace_dir(sidecar_workspace: Option<&Utf8Path>) -> Result<Utf8PathBuf> {
     Utf8PathBuf::try_from(cwd).context("current_dir was not valid UTF-8")
 }
 
-/// Default location for flycheck's dedicated `--output_user_root`,
-/// next to Bazel's own user cache root. Must live outside the
-/// workspace — Bazel 8+ errors when a repo_contents_cache falls inside
-/// the main repo. Hashed by workspace path so two projects don't share
-/// a flycheck server.
-fn default_output_user_root(workspace: &Utf8Path) -> Result<Utf8PathBuf> {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-    workspace.as_str().hash(&mut hasher);
-    let workspace_hash = format!("{:016x}", hasher.finish());
-
-    let cache_root = user_cache_dir()?.join("bazel").join("rules_rust_flycheck");
-    Ok(cache_root.join(workspace_hash))
+/// Default `--output_base` for flycheck's dedicated server: the
+/// outer server's `output_base` with an `_rra` suffix
+/// ([`flycheck_output_base`]). Both bases therefore live under the
+/// same `output_user_root` and share its `install/` extraction
+/// (~200 MB of JVM + Bazel binaries) while still holding distinct
+/// server locks.
+///
+/// Resolution order (each step avoids a `bazel info` on the outer
+/// server):
+///   1. Sidecar — written by discover on every RA discovery pass.
+///   2. Setup-populated `BazelInfo` cache — stores flycheck's own
+///      `output_base` directly, so a fresh checkout that ran setup
+///      but hasn't triggered discover yet still skips the fallback.
+///   3. `bazel info output_base` against the outer server — starts
+///      the outer server if it isn't already running.
+fn derive_output_base(
+    launcher_dir: &Utf8Path,
+    bazel: &Utf8Path,
+    workspace: &Utf8Path,
+    sidecar: Option<&ToolchainInfoSidecar>,
+) -> Result<Utf8PathBuf> {
+    if let Some(p) = sidecar.and_then(|s| s.output_base.as_deref()) {
+        return Ok(flycheck_output_base(p));
+    }
+    if let Some(cached) = BazelInfo::load(launcher_dir) {
+        return Ok(cached.output_base);
+    }
+    let outer = bazel_info_path(bazel, workspace, None, "output_base")
+        .context("deriving flycheck output_base from outer `bazel info output_base`")?;
+    Ok(flycheck_output_base(&outer))
 }
 
-/// Best-effort platform cache dir. Uses `$XDG_CACHE_HOME` when set;
-/// otherwise `~/.cache` on Linux, `~/Library/Caches` on macOS,
-/// `%LOCALAPPDATA%` on Windows.
-fn user_cache_dir() -> Result<Utf8PathBuf> {
-    if let Ok(dir) = env::var("XDG_CACHE_HOME") {
-        if !dir.is_empty() {
-            return Ok(Utf8PathBuf::from(dir));
+/// One-key `bazel info` lookup returned as a path. `output_base =
+/// None` targets the outer server; `Some(_)` targets flycheck's own
+/// server. Routes through the shared `bazel_info` helper so the
+/// env-scrub triple stays consolidated in `lib.rs`.
+fn bazel_info_path(
+    bazel: &Utf8Path,
+    workspace: &Utf8Path,
+    output_base: Option<&Utf8Path>,
+    key: &str,
+) -> Result<Utf8PathBuf> {
+    let value = bazel_info(bazel, Some(workspace), output_base, &[], &[])?
+        .remove(key)
+        .with_context(|| format!("`bazel info` returned no `{key}` line"))?;
+    Ok(Utf8PathBuf::from(value))
+}
+
+/// Return flycheck's server `execution_root`, hitting the
+/// setup-populated `BazelInfo` cache when its `output_base` still
+/// matches the current one and refreshing (one `bazel info` call,
+/// persisted for next time) otherwise. This keeps the steady-state
+/// clippy path off `bazel info` — critical because rust-analyzer
+/// spawns flycheck on every save.
+fn cached_execution_root(
+    launcher_dir: &Utf8Path,
+    bazel: &Utf8Path,
+    workspace: &Utf8Path,
+    output_base: &Utf8Path,
+) -> Result<Utf8PathBuf> {
+    if let Some(cached) = BazelInfo::load(launcher_dir) {
+        if cached.output_base == output_base {
+            return Ok(cached.execution_root);
         }
     }
-    #[cfg(target_os = "macos")]
-    {
-        let home = env::var("HOME").context("HOME not set")?;
-        Ok(Utf8PathBuf::from(home).join("Library").join("Caches"))
-    }
-    #[cfg(target_os = "windows")]
-    {
-        let dir = env::var("LOCALAPPDATA").context("LOCALAPPDATA not set")?;
-        Ok(Utf8PathBuf::from(dir))
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        let home = env::var("HOME").context("HOME not set")?;
-        Ok(Utf8PathBuf::from(home).join(".cache"))
-    }
+    let info = BazelInfo::try_new(bazel, workspace, output_base)?;
+    let er = info.execution_root.clone();
+    info.save(launcher_dir);
+    Ok(er)
 }
 
 /// Derive the Bazel label for a saved file (override mode). Fast
@@ -453,27 +509,6 @@ fn find_owning_package(workspace: &Utf8Path, file_rel: &Utf8Path) -> Option<Utf8
     }
 }
 
-/// `bazel info execution_root` against the flycheck server. Its exec
-/// root differs from discover's (different `--output_user_root`), so
-/// we can't reuse the sidecar's value.
-fn bazel_info_execution_root(bazel: &Utf8Path, output_user_root: &Utf8Path) -> Result<Utf8PathBuf> {
-    let output = Command::new(bazel.as_str())
-        .arg(format!("--output_user_root={output_user_root}"))
-        .arg("info")
-        .arg("execution_root")
-        .output()
-        .with_context(|| format!("invoking {bazel} info execution_root"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("bazel info execution_root failed: {stderr}");
-    }
-    let root = String::from_utf8(output.stdout)
-        .context("bazel info execution_root output not UTF-8")?
-        .trim()
-        .to_owned();
-    Ok(Utf8PathBuf::from(root))
-}
-
 /// Best-effort cleanup of the temporary BEP file.
 fn scopeguard(path: Utf8PathBuf) -> impl Drop {
     struct Guard(Utf8PathBuf);
@@ -535,13 +570,52 @@ mod tests {
     }
 
     #[test]
+    fn is_actionable_diagnostic_keeps_real_diagnostics_only() {
+        // Real diagnostic — at least one primary span — kept.
+        assert!(is_actionable_diagnostic(&json!({
+            "$message_type": "diagnostic",
+            "message": "unnecessary parentheses",
+            "spans": [{"is_primary": true}],
+        })));
+        // Cargo-wrapped compiler-message.
+        assert!(is_actionable_diagnostic(&json!({
+            "reason": "compiler-message",
+            "message": {"spans": [{"is_primary": true}]},
+        })));
+        // Rustc artifact — dropped. Would otherwise get parsed as
+        // a partially-valid Diagnostic by RA if any field defaults
+        // matched.
+        assert!(!is_actionable_diagnostic(&json!({
+            "$message_type": "artifact",
+            "artifact": "foo.rlib",
+            "emit": "link",
+        })));
+        // "aborting due to N errors" summary — no spans → dropped.
+        // Otherwise it flips RA's `diagnostics_received` off `NotYet`
+        // without adding anything RA can display, which prevents the
+        // NotYet → workspace-clear path from firing when a fix leaves
+        // the run with only summaries.
+        assert!(!is_actionable_diagnostic(&json!({
+            "$message_type": "diagnostic",
+            "message": "aborting due to 1 previous error",
+            "spans": [],
+        })));
+        // Non-primary span only — dropped, same reason.
+        assert!(!is_actionable_diagnostic(&json!({
+            "$message_type": "diagnostic",
+            "message": "note",
+            "spans": [{"is_primary": false}],
+        })));
+    }
+
+    #[test]
     fn rustc_stdlib_remap_gets_replaced_with_sysroot_src() {
         let workspace = Utf8Path::new("/ws");
         let sysroot_src = Utf8Path::new("/toolchain/lib/rustlib/src/library");
         let mut v = json!({
             "spans": [
                 {"file_name": "/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/result.rs"},
-                {"file_name": "/rustc/notasha/library/x.rs"},
+                {"file_name": "/rustc/marika/library/x.rs"},
                 {"file_name": "/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/bin/rustc.rs"},
             ]
         });
@@ -553,7 +627,7 @@ mod tests {
             spans[0]["file_name"],
             json!(format!("{sysroot_src}/core/src/result.rs")),
         );
-        assert_eq!(spans[1]["file_name"], json!("/rustc/notasha/library/x.rs"));
+        assert_eq!(spans[1]["file_name"], json!("/rustc/marika/library/x.rs"));
         assert_eq!(
             spans[2]["file_name"],
             json!("/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/bin/rustc.rs"),
@@ -631,7 +705,7 @@ mod tests {
     fn substitute_rustc_stdlib_leaves_non_stdlib_prefixes_alone() {
         let sysroot_src = Utf8Path::new("/toolchain/src/library");
         for input in [
-            "/rustc/notasha/library/x.rs",
+            "/rustc/marika/library/x.rs",
             "/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/bin/rustc.rs",
             "/rustc/",
         ] {

--- a/tools/rust_analyzer/bin/flycheck.rs
+++ b/tools/rust_analyzer/bin/flycheck.rs
@@ -27,21 +27,32 @@ use std::{
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
-use gen_rust_project_lib::{bep, install_dir, user_config};
+use gen_rust_project_lib::{
+    bep, install_dir, user_config, ToolchainInfoSidecar, TOOLCHAIN_INFO_SIDECAR,
+};
 use serde_json::Value;
 
 #[derive(Parser, Debug)]
 #[command(about = "rust-analyzer flycheck wrapper backed by `bazel build`")]
 struct Args {
     /// Bazel label of the crate whose owning file rust-analyzer just saved.
-    label: String,
+    /// Required in "runnable mode" (invoked from rust-project.json's
+    /// Flycheck runnable, where discover baked in the label). Omitted
+    /// in "override mode" (invoked from `check.overrideCommand`) —
+    /// pass `--saved-file <path>` instead and flycheck derives the
+    /// label via the sidecar map or a `bazel query`.
+    label: Option<String>,
 
-    /// The file rust-analyzer just saved. Currently unused — we check the
-    /// whole crate, matching cargo check's per-crate semantics. Accepted
-    /// so the runnable template's `{saved_file}` placeholder has somewhere
-    /// to land without errors.
+    /// The file rust-analyzer just saved. Positional form for runnable
+    /// mode (`<label> <saved_file>`). Ignored when `--saved-file` is set.
     #[clap(default_value = "")]
     saved_file: String,
+
+    /// Saved file for override mode (invoked from RA's
+    /// `check.overrideCommand`, which passes only `$saved_file` — no
+    /// label). Mutually exclusive with the positional `label`.
+    #[clap(long = "saved-file", conflicts_with = "label")]
+    saved_file_arg: Option<Utf8PathBuf>,
 
     /// Path to the bazel binary.
     #[clap(long, default_value = "bazel")]
@@ -67,25 +78,31 @@ fn main() -> ExitCode {
 fn run() -> Result<u8> {
     let args = Args::parse();
 
-    let workspace = workspace_dir()?;
+    let launcher_dir = install_dir()?;
+    let sidecar = load_toolchain_info(&launcher_dir);
+    let workspace = workspace_dir(sidecar.as_ref().and_then(|s| s.workspace.as_deref()))?;
+
+    // Runnable mode: label is positional. Override mode: derive it
+    // from `--saved-file` via sidecar (fast) or `bazel query` (slow).
+    let label = match (args.label.as_deref(), args.saved_file_arg.as_deref()) {
+        (Some(label), _) => label.to_owned(),
+        (None, Some(saved_file)) => {
+            resolve_label_for(&args.bazel, &workspace, sidecar.as_ref(), saved_file)?
+        }
+        (None, None) => {
+            anyhow::bail!("either a positional Bazel label or `--saved-file <path>` is required");
+        }
+    };
 
     let temp_dir = Utf8PathBuf::try_from(env::temp_dir()).context("$TMPDIR was not valid UTF-8")?;
     let bep_path = temp_dir.join(format!("flycheck_bep_{}.json", std::process::id()));
     let _bep_cleanup = scopeguard(bep_path.clone());
 
-    // Per-user preferences live in `<launcher_dir>/user_config.json`.
-    // Clippy mode is a per-user opt-in there — the shared discover
-    // command doesn't decide it — so we consult the config on every
-    // save rather than baking the choice into flycheck's argv.
-    let user = user_config::load(&install_dir()?);
+    let user = user_config::load(&launcher_dir);
 
     // Dedicated `--output_user_root` for the inner `bazel build` so
-    // its `--error_format=json` / `--rustc_output_diagnostics=true`
-    // don't thrash the user's primary Bazel server's analysis cache.
-    // Precedence: CLI flag > user_config > platform default. The
-    // default lives next to Bazel's own output roots (~/.cache/bazel
-    // on Linux) — not inside the workspace, which Bazel 8+ rejects
-    // for repo_contents_cache.
+    // its `--error_format=json` doesn't thrash the primary Bazel
+    // server's analysis cache. Precedence: CLI > user_config > default.
     let output_user_root = match args.output_user_root.clone() {
         Some(p) => p,
         None => match user.output_user_root.clone() {
@@ -96,37 +113,36 @@ fn run() -> Result<u8> {
     std::fs::create_dir_all(&output_user_root)
         .with_context(|| format!("creating output_user_root {output_user_root}"))?;
 
-    // Assemble the bazel command. Clippy mode adds the aspect and
-    // its diagnostics output group on top of the base build flags.
     let mut cmd = Command::new(args.bazel.as_str());
     cmd.current_dir(&workspace)
-        // BUILD_WORKSPACE_DIRECTORY / BUILD_WORKING_DIRECTORY leak in from
-        // the outer `bazel run` invocation and would confuse the nested
-        // bazel client; clear them so the nested call rediscovers the
-        // workspace from cwd.
+        // Clear env vars leaked from the outer `bazel run` so the
+        // nested client rediscovers the workspace from cwd.
         .env_remove("BAZELISK_SKIP_WRAPPER")
         .env_remove("BUILD_WORKING_DIRECTORY")
         .env_remove("BUILD_WORKSPACE_DIRECTORY")
-        // `--output_user_root` is a STARTUP option — must precede the
-        // command (`build`). Bazel rejects it elsewhere.
+        // `--output_user_root` is a STARTUP option, must precede `build`.
         .arg(format!("--output_user_root={output_user_root}"))
         .arg("build")
-        .arg(&args.label)
-        // `error_format=json` makes rustc emit machine-readable diagnostics
-        // and tells process_wrapper to capture them verbatim; without it the
-        // `.rustc-output` files are pre-rendered ANSI strings that
-        // rust-analyzer can't parse.
+        .arg(&label)
+        // Flags below use the apparent `@rules_rust` name (not a
+        // compile-time `ASPECT_REPOSITORY`) — `ASPECT_REPOSITORY`
+        // resolves to empty when built inside rules_rust, which
+        // produces bare `--//rust/settings:...` and only works when
+        // the outer bazel invocation is IN rules_rust.
+        //
+        // `error_format=json` makes rustc emit machine-readable
+        // diagnostics; without it the `.rustc-output` files are
+        // pre-rendered ANSI strings that RA can't parse.
         .arg("--@rules_rust//rust/settings:error_format=json")
         .arg("--@rules_rust//rust/settings:rustc_output_diagnostics=true")
         .arg(format!("--output_groups=+{}", bep::RUSTC_OUTPUT_GROUP))
         .arg("--keep_going")
         .arg(format!("--build_event_json_file={bep_path}"));
     if user.clippy {
+        // `clippy_output_diagnostics=true` gates the aspect writing
+        // JSON to the declared `.clippy.diagnostics` file (vs a
+        // marker), exposed via the `clippy_output` group.
         cmd.arg("--aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect")
-            // Diagnostics go to a declared `.clippy.diagnostics` file per
-            // crate, exposed via the `clippy_output` output group. Without
-            // this flag the aspect only emits a marker file, so we'd have
-            // nowhere to read clippy JSON from.
             .arg("--@rules_rust//rust/settings:clippy_output_diagnostics=true")
             .arg(format!("--output_groups=+{}", bep::CLIPPY_OUTPUT_GROUP));
     }
@@ -142,15 +158,12 @@ fn run() -> Result<u8> {
         }
     };
     if user.clippy {
-        // Additive: the `clippy_output` group holds `.clippy.diagnostics`
-        // files that action-stderr harvesting doesn't cover (clippy's JSON
-        // goes to the declared file, not stderr, when
-        // `clippy_output_diagnostics=true`).
+        // Additive: clippy's JSON goes to the declared
+        // `.clippy.diagnostics` file (exposed via `clippy_output`),
+        // not stderr, when `clippy_output_diagnostics=true`.
         //
-        // `parse_output_group_paths` needs the exec root to resolve BEP-
-        // relative paths (per rules_rust#4130). Fetching inline via
-        // `bazel info` — we already run bazel in this process, so one
-        // extra info call adds negligible latency to a save.
+        // `parse_output_group_paths` needs flycheck's OWN Bazel exec
+        // root to resolve BEP-relative paths (rules_rust#4130).
         match bazel_info_execution_root(&args.bazel, &output_user_root)
             .and_then(|er| bep::parse_output_group_paths(&bep_path, bep::CLIPPY_OUTPUT_GROUP, &er))
         {
@@ -159,30 +172,48 @@ fn run() -> Result<u8> {
         }
     }
 
-    emit_diagnostics(&diagnostic_files, &workspace)?;
+    let sysroot_src = sidecar.as_ref().map(|s| s.sysroot_src.as_path());
+    emit_diagnostics(&diagnostic_files, &workspace, sysroot_src)?;
 
-    // Forward Bazel's exit code so rust-analyzer can tell apart "build
-    // succeeded with diagnostics" from "build tool itself broke".
+    // Forward Bazel's exit code so RA can distinguish "build with
+    // diagnostics" from "build tool broke".
     Ok(status.code().unwrap_or(1) as u8)
 }
 
-/// Stream each action-stderr file to stdout, keeping only lines that look
-/// like rustc JSON messages. For each diagnostic line, recursively rewrite
-/// `file_name` fields to absolute paths anchored at the workspace root —
-/// rustc emits them relative to the Bazel exec root (structurally the
-/// workspace layout), and rust-analyzer otherwise tries to resolve them
-/// relative to the saved file's directory, producing nonsense like
-/// `<workspace>/util/label/util/label/label.rs`.
+/// Read the sidecar written by discover. Missing / malformed → `None`;
+/// flycheck falls back to its slow paths.
+fn load_toolchain_info(launcher_dir: &Utf8Path) -> Option<ToolchainInfoSidecar> {
+    let path = launcher_dir.join(TOOLCHAIN_INFO_SIDECAR);
+    let bytes = match fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            log::info!(
+                "toolchain_info sidecar: {path}: {e} — falling back to cwd/current defaults"
+            );
+            return None;
+        }
+    };
+    match serde_json::from_slice::<ToolchainInfoSidecar>(&bytes) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            log::warn!("toolchain_info sidecar: parsing {path}: {e}");
+            None
+        }
+    }
+}
+
+/// Stream JSON rustc diagnostics from each action-stderr file to
+/// stdout, rewriting `file_name` fields to absolute workspace paths
+/// (rustc emits them relative to the exec root; RA otherwise resolves
+/// them against the saved file's directory and produces nonsense).
 ///
-/// Non-JSON lines (sandbox warnings, env dumps) are dropped so the LSP
-/// only sees parseable rustc messages.
-///
-/// Errors writing to stdout bubble up — rust-analyzer parses our stdout
-/// as the diagnostic stream, so silently dropping writes would surface as
-/// "no squiggles after save" with no clue why. A failed write is almost
-/// always "rust-analyzer closed the pipe" which is also worth surfacing
-/// (the editor is gone; flycheck has no consumer).
-fn emit_diagnostics(files: &[Utf8PathBuf], workspace: &Utf8Path) -> Result<()> {
+/// Non-JSON lines (sandbox warnings, env dumps) pass through so we
+/// don't silently swallow an unrecognized format.
+fn emit_diagnostics(
+    files: &[Utf8PathBuf],
+    workspace: &Utf8Path,
+    sysroot_src: Option<&Utf8Path>,
+) -> Result<()> {
     let stdout = io::stdout();
     let mut out = stdout.lock();
     for path in files {
@@ -200,14 +231,13 @@ fn emit_diagnostics(files: &[Utf8PathBuf], workspace: &Utf8Path) -> Result<()> {
             }
             match serde_json::from_str::<Value>(trimmed) {
                 Ok(mut value) => {
-                    absolutize_file_names(&mut value, workspace);
+                    rewrite_file_names(&mut value, workspace, sysroot_src);
                     serde_json::to_writer(&mut out, &value)
                         .context("writing rewritten rustc JSON to stdout")?;
                     out.write_all(b"\n").context("writing newline to stdout")?;
                 }
                 Err(_) => {
-                    // Not strict JSON — pass through unmodified so we don't
-                    // silently drop a diagnostic format we don't recognize.
+                    // Not JSON — pass through unmodified.
                     out.write_all(line.as_bytes())
                         .context("passing through non-JSON line to stdout")?;
                     out.write_all(b"\n").context("writing newline to stdout")?;
@@ -219,53 +249,103 @@ fn emit_diagnostics(files: &[Utf8PathBuf], workspace: &Utf8Path) -> Result<()> {
     Ok(())
 }
 
-/// Walk a rustc-diagnostic JSON value and rewrite every `"file_name"`
-/// string field to an absolute path under `workspace`. file_name appears
-/// in `spans[*].file_name`, in nested `expansion.span.file_name` chains
-/// for macro expansions, and inside `children[*].spans[*]…` for
-/// sub-diagnostics — recursion catches all of them.
-fn absolutize_file_names(value: &mut Value, workspace: &Utf8Path) {
-    match value {
-        Value::Object(map) => {
-            for (key, child) in map.iter_mut() {
-                if key == "file_name" {
-                    if let Value::String(s) = child {
-                        if !s.is_empty() && !std::path::Path::new(s).is_absolute() {
-                            *s = workspace.join(&*s).to_string();
+/// Replace `/rustc/<40 hex>/library/` in `input` with `<sysroot_src>/`.
+/// Returns `None` when no substitution happened (common) so the caller
+/// skips the allocation.
+fn substitute_rustc_stdlib(input: &str, sysroot_src: &Utf8Path) -> Option<String> {
+    if !input.contains("/rustc/") {
+        return None;
+    }
+    let needle = "/rustc/";
+    const SHA_LEN: usize = 40;
+    const LIBRARY_SEP: &str = "/library/";
+
+    let mut out = String::with_capacity(input.len());
+    let mut cursor = 0;
+    let mut replaced = false;
+    while let Some(rel) = input[cursor..].find(needle) {
+        out.push_str(&input[cursor..cursor + rel]);
+        let after_prefix = &input[cursor + rel + needle.len()..];
+        let matched = after_prefix
+            .get(..SHA_LEN)
+            .filter(|sha| sha.bytes().all(|b| b.is_ascii_hexdigit()))
+            .and_then(|_| after_prefix.get(SHA_LEN..))
+            .and_then(|rest| rest.strip_prefix(LIBRARY_SEP));
+        if let Some(tail) = matched {
+            out.push_str(sysroot_src.as_str());
+            out.push('/');
+            cursor = input.len() - tail.len();
+            replaced = true;
+        } else {
+            out.push_str(needle);
+            cursor += rel + needle.len();
+        }
+    }
+    out.push_str(&input[cursor..]);
+    replaced.then_some(out)
+}
+
+/// Rewrite rustc-diagnostic paths in place:
+///  * Relative `file_name` → absolute under `workspace`.
+///  * `/rustc/<sha>/library/…` → `<sysroot_src>/…` in `file_name`,
+///    `rendered`, and `explanation` strings. RA extracts paths from
+///    `rendered` for VFS lookup, so rewriting only `file_name` isn't
+///    enough.
+fn rewrite_file_names(value: &mut Value, workspace: &Utf8Path, sysroot_src: Option<&Utf8Path>) {
+    let Value::Object(map) = value else {
+        if let Value::Array(items) = value {
+            for item in items.iter_mut() {
+                rewrite_file_names(item, workspace, sysroot_src);
+            }
+        }
+        return;
+    };
+    for (key, child) in map.iter_mut() {
+        match key.as_str() {
+            "file_name" => {
+                if let Value::String(s) = child {
+                    if !s.is_empty() && !std::path::Path::new(s).is_absolute() {
+                        *s = workspace.join(&*s).to_string();
+                    }
+                    if let (Some(sr), Value::String(s)) = (sysroot_src, &mut *child) {
+                        if let Some(replaced) = substitute_rustc_stdlib(s, sr) {
+                            *s = replaced;
                         }
                     }
-                } else {
-                    absolutize_file_names(child, workspace);
                 }
             }
-        }
-        Value::Array(items) => {
-            for item in items.iter_mut() {
-                absolutize_file_names(item, workspace);
+            "rendered" | "explanation" => {
+                if let (Some(sr), Value::String(s)) = (sysroot_src, child) {
+                    if let Some(replaced) = substitute_rustc_stdlib(s, sr) {
+                        *s = replaced;
+                    }
+                }
             }
+            _ => rewrite_file_names(child, workspace, sysroot_src),
         }
-        _ => {}
     }
 }
 
-fn workspace_dir() -> Result<Utf8PathBuf> {
+/// Precedence: `$BUILD_WORKSPACE_DIRECTORY` → sidecar's `workspace`
+/// (correct when RA spawns flycheck with cwd inside a package) →
+/// `env::current_dir()`.
+fn workspace_dir(sidecar_workspace: Option<&Utf8Path>) -> Result<Utf8PathBuf> {
     if let Ok(dir) = env::var("BUILD_WORKSPACE_DIRECTORY") {
         return Utf8PathBuf::try_from(std::path::PathBuf::from(dir))
             .context("BUILD_WORKSPACE_DIRECTORY was not valid UTF-8");
+    }
+    if let Some(dir) = sidecar_workspace {
+        return Ok(dir.to_path_buf());
     }
     let cwd = env::current_dir().context("current_dir")?;
     Utf8PathBuf::try_from(cwd).context("current_dir was not valid UTF-8")
 }
 
 /// Default location for flycheck's dedicated `--output_user_root`,
-/// sitting next to Bazel's own user cache root
-/// (`~/.cache/bazel/_bazel_<user>/…` on Linux, `~/Library/Caches/bazel/…`
-/// on macOS). Living outside the workspace matters on Bazel 8+, which
-/// errors when a repo_contents_cache falls inside the main repo — the
-/// old default (`<launcher_dir>/output_user_root`) always did.
-///
-/// A per-workspace subdirectory (hashed workspace path) keeps two
-/// projects from sharing a flycheck server.
+/// next to Bazel's own user cache root. Must live outside the
+/// workspace — Bazel 8+ errors when a repo_contents_cache falls inside
+/// the main repo. Hashed by workspace path so two projects don't share
+/// a flycheck server.
 fn default_output_user_root(workspace: &Utf8Path) -> Result<Utf8PathBuf> {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -304,9 +384,78 @@ fn user_cache_dir() -> Result<Utf8PathBuf> {
     }
 }
 
-/// Query `bazel info execution_root` against the flycheck server (same
-/// `--output_user_root` we used for the build). Only invoked on save
-/// when clippy is enabled — see the call site.
+/// Derive the Bazel label for a saved file (override mode). Fast
+/// path: sidecar's `file_labels` map (root modules). Fallback:
+/// `bazel query` scoped to the nearest `BUILD.bazel`.
+fn resolve_label_for(
+    bazel: &Utf8Path,
+    workspace: &Utf8Path,
+    sidecar: Option<&ToolchainInfoSidecar>,
+    saved_file: &Utf8Path,
+) -> Result<String> {
+    if let Some(sc) = sidecar {
+        if let Some(label) = sc.file_labels.get(saved_file) {
+            return Ok(label.clone());
+        }
+    }
+    query_label_for(bazel, workspace, saved_file)
+}
+
+/// `bazel query 'attr(srcs, "<file>", //<package>:*)'` scoped to the
+/// nearest `BUILD.bazel`. Returns the first match — if a file belongs
+/// to several targets, any is correct.
+fn query_label_for(
+    bazel: &Utf8Path,
+    workspace: &Utf8Path,
+    saved_file: &Utf8Path,
+) -> Result<String> {
+    let file_rel = saved_file
+        .strip_prefix(workspace)
+        .with_context(|| format!("saved file {saved_file} is not under workspace {workspace}"))?;
+    let package = find_owning_package(workspace, file_rel).with_context(|| {
+        format!("no BUILD.bazel found above {saved_file} — is this file part of a Bazel target?")
+    })?;
+    let file_basename = file_rel
+        .file_name()
+        .with_context(|| format!("saved file {saved_file} has no file name"))?;
+    let pattern = format!("//{package}:{file_basename}");
+    let query = format!("attr(srcs, {pattern:?}, //{package}:*)");
+    let output = Command::new(bazel.as_str())
+        .current_dir(workspace)
+        .arg("query")
+        .arg("--output=label")
+        .arg(&query)
+        .output()
+        .with_context(|| format!("invoking {bazel} query {query}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("bazel query failed for {query}: {stderr}");
+    }
+    String::from_utf8(output.stdout)
+        .context("bazel query output not UTF-8")?
+        .lines()
+        .find(|l| !l.is_empty())
+        .map(str::to_owned)
+        .with_context(|| format!("bazel query returned no targets for {pattern}"))
+}
+
+/// Walk up looking for `BUILD.bazel` or `BUILD`. Returns the
+/// workspace-relative package path.
+fn find_owning_package(workspace: &Utf8Path, file_rel: &Utf8Path) -> Option<Utf8PathBuf> {
+    let mut dir = file_rel.parent()?;
+    loop {
+        for name in ["BUILD.bazel", "BUILD"] {
+            if workspace.join(dir).join(name).is_file() {
+                return Some(dir.to_path_buf());
+            }
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// `bazel info execution_root` against the flycheck server. Its exec
+/// root differs from discover's (different `--output_user_root`), so
+/// we can't reuse the sidecar's value.
 fn bazel_info_execution_root(bazel: &Utf8Path, output_user_root: &Utf8Path) -> Result<Utf8PathBuf> {
     let output = Command::new(bazel.as_str())
         .arg(format!("--output_user_root={output_user_root}"))
@@ -360,21 +509,17 @@ mod tests {
                 {"spans": [{"file_name": "src/inner.rs"}]}
             ]
         });
-        absolutize_file_names(&mut v, workspace);
-        // Construct expected paths via Utf8Path::join so the test passes on
-        // both POSIX and Windows (Windows uses `\` as the separator).
+        rewrite_file_names(&mut v, workspace, None);
+        // Join via Utf8Path so the test passes on Windows too.
         let expect = |rel: &str| Value::String(workspace.join(rel).to_string());
         let spans = v["spans"].as_array().unwrap();
         assert_eq!(spans[0]["file_name"], expect("util/label/label.rs"));
-        // Absolute paths must be left untouched.
         assert_eq!(spans[1]["file_name"], json!("/already/absolute.rs"));
         assert_eq!(spans[2]["file_name"], expect("src/lib.rs"));
-        // Recursive descent reaches the expansion span.
         assert_eq!(
             spans[2]["expansion"]["span"]["file_name"],
             expect("src/macro.rs"),
         );
-        // And children's spans.
         assert_eq!(
             v["children"][0]["spans"][0]["file_name"],
             expect("src/inner.rs"),
@@ -385,7 +530,115 @@ mod tests {
     fn empty_file_name_is_left_alone() {
         let workspace = Utf8Path::new("/ws");
         let mut v = json!({"spans": [{"file_name": ""}]});
-        absolutize_file_names(&mut v, workspace);
+        rewrite_file_names(&mut v, workspace, None);
         assert_eq!(v["spans"][0]["file_name"], json!(""));
+    }
+
+    #[test]
+    fn rustc_stdlib_remap_gets_replaced_with_sysroot_src() {
+        let workspace = Utf8Path::new("/ws");
+        let sysroot_src = Utf8Path::new("/toolchain/lib/rustlib/src/library");
+        let mut v = json!({
+            "spans": [
+                {"file_name": "/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/result.rs"},
+                {"file_name": "/rustc/notasha/library/x.rs"},
+                {"file_name": "/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/bin/rustc.rs"},
+            ]
+        });
+        rewrite_file_names(&mut v, workspace, Some(sysroot_src));
+        let spans = v["spans"].as_array().unwrap();
+        // Impl always emits forward slashes at the substitution boundary
+        // (rustc's stdlib remap is `/`-separated on every platform).
+        assert_eq!(
+            spans[0]["file_name"],
+            json!(format!("{sysroot_src}/core/src/result.rs")),
+        );
+        assert_eq!(spans[1]["file_name"], json!("/rustc/notasha/library/x.rs"));
+        assert_eq!(
+            spans[2]["file_name"],
+            json!("/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/bin/rustc.rs"),
+        );
+    }
+
+    #[test]
+    fn rustc_stdlib_remap_left_alone_when_sysroot_src_missing() {
+        // No sidecar → no substitution; RA logs its own VFS miss.
+        let workspace = Utf8Path::new("/ws");
+        let mut v = json!({
+            "spans": [{"file_name": "/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/result.rs"}]
+        });
+        rewrite_file_names(&mut v, workspace, None);
+        assert_eq!(
+            v["spans"][0]["file_name"],
+            json!("/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/result.rs"),
+        );
+    }
+
+    #[test]
+    fn rustc_stdlib_remap_gets_replaced_inside_rendered_field() {
+        // RA parses paths out of `rendered` for VFS lookup — rewriting
+        // only `file_name` isn't enough.
+        let workspace = Utf8Path::new("/ws");
+        let sysroot_src = Utf8Path::new("/toolchain/lib/rustlib/src/library");
+        let mut v = json!({
+            "rendered": "note: tuple variant defined here\n  --> /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/result.rs:561:4\n\n"
+        });
+        rewrite_file_names(&mut v, workspace, Some(sysroot_src));
+        assert_eq!(
+            v["rendered"],
+            json!("note: tuple variant defined here\n  --> /toolchain/lib/rustlib/src/library/core/src/result.rs:561:4\n\n"),
+        );
+    }
+
+    #[test]
+    fn multiple_rustc_prefixes_all_rewritten() {
+        let sysroot_src = Utf8Path::new("/toolchain/src/library");
+        let out = substitute_rustc_stdlib(
+            "at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/mod.rs and /rustc/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/library/alloc/vec.rs done",
+            sysroot_src,
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "at /toolchain/src/library/core/mod.rs and /toolchain/src/library/alloc/vec.rs done"
+        );
+    }
+
+    #[test]
+    fn workspace_dir_prefers_env_over_sidecar() {
+        // env::set_var isn't safe under parallel tests, so call twice:
+        // env absent → sidecar wins; env present → env wins.
+        struct Guard;
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                env::remove_var("BUILD_WORKSPACE_DIRECTORY");
+            }
+        }
+        let _g = Guard;
+
+        let sidecar_ws = Utf8Path::new("/from/sidecar");
+        env::remove_var("BUILD_WORKSPACE_DIRECTORY");
+        assert_eq!(workspace_dir(Some(sidecar_ws)).unwrap(), sidecar_ws);
+
+        env::set_var("BUILD_WORKSPACE_DIRECTORY", "/from/env");
+        assert_eq!(
+            workspace_dir(Some(sidecar_ws)).unwrap(),
+            Utf8Path::new("/from/env"),
+        );
+    }
+
+    #[test]
+    fn substitute_rustc_stdlib_leaves_non_stdlib_prefixes_alone() {
+        let sysroot_src = Utf8Path::new("/toolchain/src/library");
+        for input in [
+            "/rustc/notasha/library/x.rs",
+            "/rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/bin/rustc.rs",
+            "/rustc/",
+        ] {
+            assert!(
+                substitute_rustc_stdlib(input, sysroot_src).is_none(),
+                "expected no rewrite for {input}"
+            );
+        }
     }
 }

--- a/tools/rust_analyzer/bin/gen_rust_project.rs
+++ b/tools/rust_analyzer/bin/gen_rust_project.rs
@@ -30,7 +30,6 @@ fn write_rust_project() -> anyhow::Result<()> {
         &bazel_args,
         rules_rust_name,
         &targets,
-        false,
     )?;
 
     let rust_project_path = &workspace.join("rust-project.json");

--- a/tools/rust_analyzer/bin/setup.rs
+++ b/tools/rust_analyzer/bin/setup.rs
@@ -70,7 +70,8 @@ const LAUNCHER_SUBDIR: &str = ".rules_rust_analyzer";
 // Re-exported so install (setup) and consumer (rust_project.rs)
 // agree on the `.exe` filenames.
 use gen_rust_project_lib::{
-    user_config, CACHE_SUBDIR, DISCOVER_BINARY_FILENAME, FLYCHECK_BINARY_FILENAME,
+    bazel_command, bazel_info, flycheck_output_base, user_config, BazelInfo, ToolchainInfoSidecar,
+    CACHE_SUBDIR, DISCOVER_BINARY_FILENAME, FLYCHECK_BINARY_FILENAME, TOOLCHAIN_INFO_SIDECAR,
 };
 
 // `_opt` targets the `opt_executable` wrapper — these run on every
@@ -133,19 +134,20 @@ struct Cli {
     #[arg(long, conflicts_with = "clippy", global = true)]
     no_clippy: bool,
 
-    /// Delete the discover cache (`<launcher-dir>/cache/`) before
-    /// running the rest of setup. Use after a toolchain change or
-    /// `bazel clean --expunge`. Does not touch `user_config.json` or
-    /// flycheck's `output_user_root/`.
+    /// Delete the discover cache (`<launcher-dir>/cache/`) AND wipe
+    /// flycheck's dedicated `output_base` (via `bazel clean --expunge
+    /// --output_base=<...>`). Use after a toolchain change. Reads the
+    /// flycheck base from the sidecar; a no-op for it if no sidecar
+    /// exists yet. Does not touch `user_config.json`.
     #[arg(long, global = true)]
     clean: bool,
 
     /// Persist a per-user override for flycheck's inner
-    /// `--output_user_root`, into `<launcher_dir>/user_config.json`.
-    /// The flycheck CLI flag still wins for one-off overrides. Clear
-    /// by hand-deleting the key from `user_config.json`.
+    /// `--output_base`, into `<launcher_dir>/user_config.json`. The
+    /// flycheck CLI flag still wins for one-off overrides. Clear by
+    /// hand-deleting the key from `user_config.json`.
     #[arg(long, global = true, value_name = "PATH")]
-    output_user_root: Option<Utf8PathBuf>,
+    output_base: Option<Utf8PathBuf>,
 
     #[command(subcommand)]
     ide: IdeCmd,
@@ -236,9 +238,9 @@ fn apply_user_config_edits(
     launcher_dir: &Utf8Path,
     clippy: Option<bool>,
     per_package_workspaces: Option<bool>,
-    output_user_root: Option<Utf8PathBuf>,
+    output_base: Option<Utf8PathBuf>,
 ) -> Result<()> {
-    if clippy.is_none() && per_package_workspaces.is_none() && output_user_root.is_none() {
+    if clippy.is_none() && per_package_workspaces.is_none() && output_base.is_none() {
         return Ok(());
     }
     let mut config = user_config::load(launcher_dir);
@@ -248,13 +250,13 @@ fn apply_user_config_edits(
     if let Some(v) = per_package_workspaces {
         config.per_package_workspaces = v;
     }
-    if let Some(v) = output_user_root {
-        config.output_user_root = Some(v);
+    if let Some(v) = output_base {
+        config.output_base = Some(v);
     }
     user_config::save(launcher_dir, &config)?;
     info!(
-        "user_config: clippy={} per_package_workspaces={} output_user_root={:?}",
-        config.clippy, config.per_package_workspaces, config.output_user_root
+        "user_config: clippy={} per_package_workspaces={} output_base={:?}",
+        config.clippy, config.per_package_workspaces, config.output_base
     );
     Ok(())
 }
@@ -269,7 +271,7 @@ fn main() -> Result<()> {
         clippy,
         no_clippy,
         clean,
-        output_user_root,
+        output_base,
         ide,
     } = Cli::parse();
 
@@ -296,7 +298,7 @@ fn main() -> Result<()> {
     let launcher_dir = launcher_dir_for(&workspace, &ide);
 
     if clean {
-        clean_cache(&launcher_dir)?;
+        clean_cache(&launcher_dir, &workspace)?;
     }
 
     let runfiles = Runfiles::create().context("creating Runfiles for setup")?;
@@ -318,7 +320,13 @@ fn main() -> Result<()> {
 
     // Apply user_config edits before per-IDE dispatch so the runners
     // and any --dry-run flow see the same on-disk state.
-    apply_user_config_edits(&launcher_dir, pending_clippy, pending_ppw, output_user_root)?;
+    apply_user_config_edits(&launcher_dir, pending_clippy, pending_ppw, output_base)?;
+
+    // Pre-populate the flycheck server's bazel-info cache so the
+    // steady-state clippy path never invokes `bazel info` on save.
+    // Best-effort — a failure just means flycheck refreshes on first
+    // save (its normal fallback path). See [`prepopulate_bazel_info`].
+    prepopulate_bazel_info(&launcher_dir, &workspace);
 
     let ctx = SetupCtx {
         launcher_dir,
@@ -338,10 +346,9 @@ fn main() -> Result<()> {
 /// Shared state computed once at startup and threaded through every
 /// per-IDE runner.
 struct SetupCtx {
-    /// Editor-specific dir setup copies source binaries into. The
-    /// discover/flycheck binaries self-locate their cache + output dirs
-    /// as siblings of themselves (`<launcher_dir>/cache` and
-    /// `<launcher_dir>/output_user_root` respectively).
+    /// Editor-specific dir setup copies source binaries into. Discover
+    /// self-locates its cache at `<launcher_dir>/cache/`; flycheck
+    /// derives its `--output_base` from the sidecar written here.
     launcher_dir: Utf8PathBuf,
     skip_proc_macro_server: bool,
     skip_rustfmt: bool,
@@ -562,21 +569,125 @@ fn run_print(ctx: &SetupCtx) -> Result<()> {
 // Source-binary install
 // ---------------------------------------------------------------------------
 
-/// Delete the discover-output cache under `launcher_dir`. Called on
-/// `--clean`. Leaves everything else in `launcher_dir` alone
-/// (`user_config.json` is per-user prefs; `output_user_root/` is
-/// flycheck's Bazel build tree, expensive to rebuild). Missing dir is
-/// not an error — clean is idempotent.
-fn clean_cache(launcher_dir: &Utf8Path) -> Result<()> {
+/// Called on `--clean`. Deletes the discover-output cache under
+/// `launcher_dir`, the flycheck `bazel_info.json` cache (invalid
+/// once the flycheck server is expunged), AND expunges flycheck's
+/// dedicated `output_base` (`<sidecar.output_base>_rra`) via `bazel
+/// clean --expunge`. Leaves `user_config.json` alone (per-user prefs).
+/// All steps are idempotent: missing paths are fine, missing sidecar /
+/// missing bazel just skips the expunge with a warning.
+fn clean_cache(launcher_dir: &Utf8Path, workspace: &Utf8Path) -> Result<()> {
     let cache = launcher_dir.join(CACHE_SUBDIR);
     match fs::remove_dir_all(&cache) {
-        Ok(()) => {
-            eprintln!("cleared discover cache at {cache}");
-            Ok(())
-        }
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e).with_context(|| format!("removing discover cache at {cache}")),
+        Ok(()) => eprintln!("cleared discover cache at {cache}"),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e).with_context(|| format!("removing discover cache at {cache}")),
     }
+    // The stored `execution_root` becomes meaningless once its server
+    // is expunged below, so drop the cache first.
+    let _ = fs::remove_file(launcher_dir.join(gen_rust_project_lib::BAZEL_INFO_FILENAME));
+    expunge_flycheck_output_base(launcher_dir, workspace);
+    Ok(())
+}
+
+/// Best-effort `bazel --output_base=<...> clean --expunge` for
+/// flycheck's dedicated server. `--expunge` handles the server
+/// shutdown before removing the directory — no separate `bazel
+/// shutdown` step needed. Warns and continues on any failure: `--clean`
+/// is a nice-to-have wipe, not a load-bearing operation, and there's
+/// nothing to clean before discover has ever run.
+fn expunge_flycheck_output_base(launcher_dir: &Utf8Path, workspace: &Utf8Path) {
+    let sidecar_path = launcher_dir.join(TOOLCHAIN_INFO_SIDECAR);
+    let Some(outer) = fs::read(&sidecar_path)
+        .ok()
+        .and_then(|b| serde_json::from_slice::<ToolchainInfoSidecar>(&b).ok())
+        .and_then(|s| s.output_base)
+    else {
+        eprintln!(
+            "no sidecar at {sidecar_path}; skipping flycheck output_base expunge (nothing to \
+             clean before rust-analyzer discovery has run)"
+        );
+        return;
+    };
+    let flycheck_base = flycheck_output_base(&outer);
+    if !flycheck_base.exists() {
+        return;
+    }
+    let status = bazel_command(
+        Utf8Path::new("bazel"),
+        Some(workspace),
+        Some(&flycheck_base),
+    )
+    .arg("clean")
+    .arg("--expunge")
+    .status();
+    match status {
+        Ok(s) if s.success() => eprintln!("expunged flycheck output_base at {flycheck_base}"),
+        Ok(s) => eprintln!(
+            "bazel clean --expunge on flycheck output_base {flycheck_base} exited with {s}; \
+             leaving the directory as-is"
+        ),
+        Err(e) => eprintln!(
+            "could not invoke `bazel` to expunge flycheck output_base at {flycheck_base}: {e}; \
+             delete it by hand if needed"
+        ),
+    }
+}
+
+/// Populate `<launcher_dir>/bazel_info.json` by invoking `bazel info`
+/// against flycheck's dedicated server. Setup runs before discover on
+/// a fresh checkout, so the sidecar may not exist yet — falls back to
+/// `bazel info output_base` against the outer server to derive the
+/// `_rra` sibling. Best-effort throughout: any failure logs and
+/// returns, and flycheck's first save will populate the cache instead.
+fn prepopulate_bazel_info(launcher_dir: &Utf8Path, workspace: &Utf8Path) {
+    let bazel = Utf8Path::new("bazel");
+    let user = user_config::load(launcher_dir);
+    let flycheck_base = match resolve_flycheck_output_base(bazel, workspace, launcher_dir, &user) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "flycheck bazel_info prepopulate: could not resolve output_base ({e:#}); \
+                 flycheck will populate on first save"
+            );
+            return;
+        }
+    };
+    match BazelInfo::try_new(bazel, workspace, &flycheck_base) {
+        Ok(info) => {
+            info.save(launcher_dir);
+            eprintln!("populated flycheck bazel_info cache at {launcher_dir}");
+        }
+        Err(e) => eprintln!(
+            "flycheck bazel_info prepopulate: {e:#}; flycheck will populate on first save"
+        ),
+    }
+}
+
+/// Same precedence flycheck uses on save (user_config, then sidecar's
+/// `_rra`, then a `bazel info output_base` against the outer server),
+/// minus the CLI override (setup doesn't take one).
+fn resolve_flycheck_output_base(
+    bazel: &Utf8Path,
+    workspace: &Utf8Path,
+    launcher_dir: &Utf8Path,
+    user: &user_config::UserConfig,
+) -> Result<Utf8PathBuf> {
+    if let Some(p) = user.output_base.clone() {
+        return Ok(p);
+    }
+    let sidecar_path = launcher_dir.join(TOOLCHAIN_INFO_SIDECAR);
+    if let Some(outer) = fs::read(&sidecar_path)
+        .ok()
+        .and_then(|b| serde_json::from_slice::<ToolchainInfoSidecar>(&b).ok())
+        .and_then(|s| s.output_base)
+    {
+        return Ok(flycheck_output_base(&outer));
+    }
+    let outer = bazel_info(bazel, Some(workspace), None, &[], &[])?
+        .remove("output_base")
+        .context("outer `bazel info` returned no `output_base` line")?;
+    Ok(flycheck_output_base(Utf8Path::new(&outer)))
 }
 
 /// Copy discover + flycheck into `dir`. The runfiles originals live
@@ -1366,7 +1477,7 @@ mod tests {
             &user_config::UserConfig {
                 clippy: false,
                 per_package_workspaces: true,
-                output_user_root: Some(Utf8PathBuf::from("/existing/root")),
+                output_base: Some(Utf8PathBuf::from("/existing/base")),
             },
         )
         .unwrap();
@@ -1380,25 +1491,25 @@ mod tests {
             "unnamed fields must be preserved: got {loaded:?}",
         );
         assert_eq!(
-            loaded.output_user_root,
-            Some(Utf8PathBuf::from("/existing/root")),
+            loaded.output_base,
+            Some(Utf8PathBuf::from("/existing/base")),
             "unnamed fields must be preserved: got {loaded:?}",
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
-    fn apply_user_config_edits_persists_output_user_root() {
-        let dir = std::env::temp_dir().join(format!("setup_uc_our_{}", std::process::id()));
+    fn apply_user_config_edits_persists_output_base() {
+        let dir = std::env::temp_dir().join(format!("setup_uc_ob_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let launcher_dir = Utf8PathBuf::try_from(dir.clone()).unwrap();
-        let path = Utf8PathBuf::from("/custom/flycheck/root");
+        let path = Utf8PathBuf::from("/custom/flycheck/base");
 
         apply_user_config_edits(&launcher_dir, None, None, Some(path.clone())).unwrap();
 
         let loaded = user_config::load(&launcher_dir);
-        assert_eq!(loaded.output_user_root, Some(path));
+        assert_eq!(loaded.output_base, Some(path));
         assert!(!loaded.clippy, "unrelated fields must stay default");
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1468,7 +1579,10 @@ mod tests {
         std::fs::create_dir_all(ws.join("cache")).unwrap();
         std::fs::write(ws.join("cache").join("entry.json"), "{}").unwrap();
 
-        clean_cache(&ws).unwrap();
+        // Second arg is workspace cwd for the bazel expunge step; with
+        // no sidecar in `ws`, that step is a no-op — the test only
+        // exercises the discover-cache half.
+        clean_cache(&ws, &ws).unwrap();
         assert!(!ws.join("cache").exists(), "cache dir should be gone");
         assert!(
             ws.join("user_config.json").exists(),
@@ -1477,7 +1591,7 @@ mod tests {
         assert!(ws.join("rust_analyzer.exe").exists(), "launcher preserved");
 
         // Idempotent: second call on now-missing dir is fine.
-        clean_cache(&ws).unwrap();
+        clean_cache(&ws, &ws).unwrap();
         let _ = std::fs::remove_dir_all(&ws);
     }
 

--- a/tools/rust_analyzer/bin/setup.rs
+++ b/tools/rust_analyzer/bin/setup.rs
@@ -166,6 +166,16 @@ struct Cli {
     #[arg(long, global = true)]
     clean: bool,
 
+    /// Persist a per-user override for flycheck's inner Bazel
+    /// `--output_user_root`. Writes the path into
+    /// `<launcher_dir>/user_config.json` so it survives future setup
+    /// runs without touching the shared committed settings file.
+    /// The `--output_user_root` flag on the flycheck binary still
+    /// wins over this. To clear, delete the `output_user_root` key
+    /// from `user_config.json` by hand.
+    #[arg(long, global = true, value_name = "PATH")]
+    output_user_root: Option<Utf8PathBuf>,
+
     #[command(subcommand)]
     ide: IdeCmd,
 }
@@ -259,8 +269,9 @@ fn apply_user_config_edits(
     launcher_dir: &Utf8Path,
     clippy: Option<bool>,
     per_package_workspaces: Option<bool>,
+    output_user_root: Option<Utf8PathBuf>,
 ) -> Result<()> {
-    if clippy.is_none() && per_package_workspaces.is_none() {
+    if clippy.is_none() && per_package_workspaces.is_none() && output_user_root.is_none() {
         return Ok(());
     }
     let mut config = user_config::load(launcher_dir);
@@ -270,10 +281,13 @@ fn apply_user_config_edits(
     if let Some(v) = per_package_workspaces {
         config.per_package_workspaces = v;
     }
+    if let Some(v) = output_user_root {
+        config.output_user_root = Some(v);
+    }
     user_config::save(launcher_dir, &config)?;
     info!(
-        "user_config: clippy={} per_package_workspaces={}",
-        config.clippy, config.per_package_workspaces
+        "user_config: clippy={} per_package_workspaces={} output_user_root={:?}",
+        config.clippy, config.per_package_workspaces, config.output_user_root
     );
     Ok(())
 }
@@ -289,6 +303,7 @@ fn main() -> Result<()> {
         clippy,
         no_clippy,
         clean,
+        output_user_root,
         ide,
     } = Cli::parse();
 
@@ -333,7 +348,7 @@ fn main() -> Result<()> {
     // and the per-IDE runners themselves see a consistent on-disk
     // state, and running `setup --clippy` with no IDE change still
     // takes effect.
-    apply_user_config_edits(&launcher_dir, pending_clippy, pending_ppw)?;
+    apply_user_config_edits(&launcher_dir, pending_clippy, pending_ppw, output_user_root)?;
 
     let ctx = SetupCtx {
         launcher_dir,
@@ -1407,11 +1422,12 @@ mod tests {
             &user_config::UserConfig {
                 clippy: false,
                 per_package_workspaces: true,
+                output_user_root: Some(Utf8PathBuf::from("/existing/root")),
             },
         )
         .unwrap();
 
-        apply_user_config_edits(&launcher_dir, Some(true), None).unwrap();
+        apply_user_config_edits(&launcher_dir, Some(true), None, None).unwrap();
 
         let loaded = user_config::load(&launcher_dir);
         assert!(loaded.clippy, "--clippy must land in the file");
@@ -1419,6 +1435,30 @@ mod tests {
             loaded.per_package_workspaces,
             "unnamed fields must be preserved: got {loaded:?}",
         );
+        assert_eq!(
+            loaded.output_user_root,
+            Some(Utf8PathBuf::from("/existing/root")),
+            "unnamed fields must be preserved: got {loaded:?}",
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn apply_user_config_edits_persists_output_user_root() {
+        // `setup --output-user-root /some/path` writes the path into
+        // the launcher-dir user_config, so flycheck picks it up on
+        // future saves without any committed-file change.
+        let dir = std::env::temp_dir().join(format!("setup_uc_our_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let launcher_dir = Utf8PathBuf::try_from(dir.clone()).unwrap();
+        let path = Utf8PathBuf::from("/custom/flycheck/root");
+
+        apply_user_config_edits(&launcher_dir, None, None, Some(path.clone())).unwrap();
+
+        let loaded = user_config::load(&launcher_dir);
+        assert_eq!(loaded.output_user_root, Some(path));
+        assert!(!loaded.clippy, "unrelated fields must stay default");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1432,7 +1472,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let launcher_dir = Utf8PathBuf::try_from(dir.clone()).unwrap();
 
-        apply_user_config_edits(&launcher_dir, None, None).unwrap();
+        apply_user_config_edits(&launcher_dir, None, None, None).unwrap();
 
         assert!(!launcher_dir
             .join(user_config::USER_CONFIG_FILENAME)

--- a/tools/rust_analyzer/bin/setup.rs
+++ b/tools/rust_analyzer/bin/setup.rs
@@ -45,50 +45,42 @@ const DISCOVER_CONFIG_KEY: &str = "rust-analyzer.workspace.discoverConfig";
 const SERVER_PATH_KEY: &str = "rust-analyzer.server.path";
 const PROC_MACRO_SRV_KEY: &str = "rust-analyzer.procMacro.server";
 const RUSTFMT_OVERRIDE_KEY: &str = "rust-analyzer.rustfmt.overrideCommand";
+/// Load-bearing: without this override, RA falls back to `cargo
+/// check` for any auto-detected `Cargo.toml`, creating `target/` and
+/// emitting cargo-anchored diagnostic paths.
+const CHECK_OVERRIDE_KEY: &str = "rust-analyzer.check.overrideCommand";
 
 const FILES_WATCHER_EXCLUDE_KEY: &str = "files.watcherExclude";
 const FILES_EXCLUDE_KEY: &str = "files.exclude";
 const SEARCH_EXCLUDE_KEY: &str = "search.exclude";
 
-/// Glob that matches Bazel's four convenience symlinks at the workspace
-/// root: `bazel-bin/`, `bazel-out/`, `bazel-testlogs/`, and
-/// `bazel-<workspace-name>/`. Skipping them is the difference between a
-/// happy IDE and one that thrashes the OS file-watch limit on every
-/// `bazel build`.
+/// Bazel's convenience symlinks (`bazel-bin/`, `bazel-out/`, etc).
+/// Skipping them keeps the OS file-watch limit from thrashing on
+/// every `bazel build`.
 const BAZEL_OUTPUTS_GLOB: &str = "**/bazel-*/**";
 
 // ---------------------------------------------------------------------------
 // Launcher dir + source-binary install paths
 // ---------------------------------------------------------------------------
 
-/// Subdirectory name used (under the per-IDE launcher root) to hold the
-/// source binaries setup copies in. The leading dot keeps tidy file
-/// explorers from surfacing it as workspace content; the rules_rust
-/// prefix prevents collisions with anything else that might want to drop
-/// files into the same parent dir.
+/// Dotted, rules_rust-prefixed dir under the per-IDE launcher root
+/// for the source binaries setup copies in.
 const LAUNCHER_SUBDIR: &str = ".rules_rust_analyzer";
 
-// On-disk filenames setup uses for the binaries it copies into the
-// launcher dir. Re-exported from `gen_rust_project_lib` so the install
-// side and the consumer side (rust_project.rs's flycheck-runnable
-// path emitter) agree on extension handling — including the `.exe`
-// suffix on Windows.
+// Re-exported so install (setup) and consumer (rust_project.rs)
+// agree on the `.exe` filenames.
 use gen_rust_project_lib::{
     user_config, CACHE_SUBDIR, DISCOVER_BINARY_FILENAME, FLYCHECK_BINARY_FILENAME,
 };
 
-// Runfiles paths setup looks up via `Runfiles::create()` at install
-// time. The `_opt` suffix points at the `opt_executable` wrapper in
-// `opt_transition.bzl` — these run on every save / discovery and pay
-// off in opt mode.
+// `_opt` targets the `opt_executable` wrapper — these run on every
+// save/discovery and pay off in opt mode.
 const DISCOVER_BINARY_RLOCATION: &str =
     "rules_rust/tools/rust_analyzer/discover_bazel_rust_project_opt";
 const FLYCHECK_BINARY_RLOCATION: &str = "rules_rust/tools/rust_analyzer/flycheck_opt";
 
-/// Source of truth for the launcher dispatch table: each entry is
-/// both the install filename (`<name>.exe`) and the
-/// `launcher_paths.json` key the launcher looks itself up under at
-/// runtime. Keep in sync with [`toolchain_target_for`].
+/// Install filename (`<name>.exe`) + `launcher_paths.json` key for
+/// each launcher. Keep in sync with [`toolchain_target_for`].
 const LAUNCHER_LOGICAL_NAMES: &[&str] =
     &["rust_analyzer", "rust_analyzer_proc_macro_srv", "rustfmt"];
 
@@ -108,11 +100,6 @@ fn launcher_filename(logical: &str) -> String {
     about = "Bootstrap an editor at the Bazel rust-analyzer toolchain."
 )]
 struct Cli {
-    /// Workspace root. Defaults to BUILD_WORKSPACE_DIRECTORY (set when
-    /// invoked via `bazel run`).
-    #[arg(long, env = "BUILD_WORKSPACE_DIRECTORY", global = true)]
-    workspace: Option<Utf8PathBuf>,
-
     /// Skip the proc-macro server key. Useful when the editor's bundled
     /// rust-analyzer already matches the Bazel rustc version.
     #[arg(long, global = true)]
@@ -123,56 +110,40 @@ struct Cli {
     #[arg(long, global = true)]
     skip_rustfmt: bool,
 
-    /// Opt this developer into per-package workspace switching. Writes
-    /// `{"per_package_workspaces": true}` into the local
-    /// `<launcher_dir>/user_config.json` — the shared committed
-    /// settings file is unaffected. `--no-per-package-workspaces` flips
-    /// it back off. Without either flag the file is left alone.
-    ///
-    /// When on, discover scopes each save to the file's owning
-    /// package instead of re-emitting the whole workspace. Turn this
-    /// on for monorepos where indexing the whole graph hurts LSP
-    /// responsiveness; the trade-off is that rust-analyzer reloads
-    /// (and re-runs discover) every time you jump to a file in a
-    /// different package, AND that dependents of the package you're
-    /// working on aren't indexed.
+    /// Pin per-package workspace switching ON (the default). Only
+    /// matters if `--no-per-package-workspaces` previously flipped it
+    /// off. Persists to `<launcher_dir>/user_config.json`.
     #[arg(long, conflicts_with = "no_per_package_workspaces", global = true)]
     per_package_workspaces: bool,
 
-    /// Opt this developer OUT of per-package workspace switching. See
-    /// `--per-package-workspaces`.
+    /// Opt out of per-package workspace switching — RA loads the
+    /// whole aspect graph. Tens of GB RSS on real monorepos; only
+    /// pick this if you need cross-package "find usages".
     #[arg(long, conflicts_with = "per_package_workspaces", global = true)]
     no_per_package_workspaces: bool,
 
-    /// Opt this developer into running clippy on save and streaming
-    /// its diagnostics alongside rustc's. Writes
-    /// `{"clippy": true}` into the local
-    /// `<launcher_dir>/user_config.json` — the shared committed
-    /// settings file is unaffected. `--no-clippy` flips it back off.
-    /// Without either flag the file is left alone.
+    /// Opt in to running clippy on save. Writes `{"clippy": true}`
+    /// into `<launcher_dir>/user_config.json`; the shared committed
+    /// settings file is unaffected. `--no-clippy` flips it back off;
+    /// omitting both leaves the file alone.
     #[arg(long, conflicts_with = "no_clippy", global = true)]
     clippy: bool,
 
-    /// Opt this developer OUT of running clippy on save. See `--clippy`.
+    /// Opt out of running clippy on save. See `--clippy`.
     #[arg(long, conflicts_with = "clippy", global = true)]
     no_clippy: bool,
 
     /// Delete the discover cache (`<launcher-dir>/cache/`) before
-    /// running the rest of setup. Use when rust-analyzer is serving
-    /// stale symbols after a toolchain change or `bazel clean
-    /// --expunge` — the next discover invocation re-populates the
-    /// cache from scratch. Does not touch `user_config.json` or
+    /// running the rest of setup. Use after a toolchain change or
+    /// `bazel clean --expunge`. Does not touch `user_config.json` or
     /// flycheck's `output_user_root/`.
     #[arg(long, global = true)]
     clean: bool,
 
-    /// Persist a per-user override for flycheck's inner Bazel
-    /// `--output_user_root`. Writes the path into
-    /// `<launcher_dir>/user_config.json` so it survives future setup
-    /// runs without touching the shared committed settings file.
-    /// The `--output_user_root` flag on the flycheck binary still
-    /// wins over this. To clear, delete the `output_user_root` key
-    /// from `user_config.json` by hand.
+    /// Persist a per-user override for flycheck's inner
+    /// `--output_user_root`, into `<launcher_dir>/user_config.json`.
+    /// The flycheck CLI flag still wins for one-off overrides. Clear
+    /// by hand-deleting the key from `user_config.json`.
     #[arg(long, global = true, value_name = "PATH")]
     output_user_root: Option<Utf8PathBuf>,
 
@@ -205,7 +176,7 @@ enum IdeCmd {
 #[derive(Args)]
 struct VscodeArgs {
     /// `.vscode/settings.json` file to write. Relative paths are
-    /// resolved under `--workspace`. Defaults to
+    /// resolved under the workspace. Defaults to
     /// `<workspace>/.vscode/settings.json` — always written.
     #[arg(long)]
     settings_json: Option<Utf8PathBuf>,
@@ -247,10 +218,8 @@ struct VscodeArgs {
 // Entry point + per-IDE dispatch
 // ---------------------------------------------------------------------------
 
-/// Resolve a `--foo` / `--no-foo` flag pair (mutually exclusive via
-/// `clap::conflicts_with`) to a tri-state: `Some(true)` for `--foo`,
-/// `Some(false)` for `--no-foo`, `None` when neither was given
-/// (leave existing state alone).
+/// Resolve a `--foo` / `--no-foo` pair: `Some(true)` for `--foo`,
+/// `Some(false)` for `--no-foo`, `None` when neither is given.
 fn pick_toggle(on: bool, off: bool) -> Option<bool> {
     if on {
         Some(true)
@@ -262,9 +231,7 @@ fn pick_toggle(on: bool, off: bool) -> Option<bool> {
 }
 
 /// Merge the CLI-provided toggles into `<launcher_dir>/user_config.json`.
-/// Only the fields the user actually named are touched; anything else
-/// in the file is preserved so future keys added by other flags don't
-/// get clobbered by an unrelated `setup --clippy` run.
+/// Only touches named fields — unrelated keys are preserved.
 fn apply_user_config_edits(
     launcher_dir: &Utf8Path,
     clippy: Option<bool>,
@@ -295,7 +262,6 @@ fn apply_user_config_edits(
 fn main() -> Result<()> {
     env_logger::init();
     let Cli {
-        workspace,
         skip_proc_macro_server,
         skip_rustfmt,
         per_package_workspaces,
@@ -307,7 +273,15 @@ fn main() -> Result<()> {
         ide,
     } = Cli::parse();
 
-    let workspace = workspace.unwrap_or_else(|| Utf8PathBuf::from("."));
+    // Setup must run under `bazel run` so the discover / flycheck
+    // binaries embed toolchain paths resolved by the TARGET
+    // workspace's Bazel — cross-workspace deploys would bake in the
+    // wrong sysroot.
+    let workspace = std::env::var("BUILD_WORKSPACE_DIRECTORY")
+        .map(Utf8PathBuf::from)
+        .context(
+            "BUILD_WORKSPACE_DIRECTORY unset — run via `bazel run @rules_rust//tools/rust_analyzer:setup`",
+        )?;
 
     // Tri-state resolution of the per-user opt-ins: explicit flag wins,
     // otherwise the file is left as-is. `clap`'s `conflicts_with` above
@@ -336,18 +310,14 @@ fn main() -> Result<()> {
     };
 
     install_source_binaries(&launcher_dir, &runfiles)?;
-    // Launcher shims are only referenced by the VSCode subcommand's
-    // managed keys; neovim / helix / print snippets bake absolute
-    // toolchain paths directly and don't go through the launchers.
+    // Only VSCode goes through launcher shims; other IDEs bake
+    // absolute toolchain paths into their snippets.
     if matches!(ide, IdeCmd::Vscode(_)) {
         install_toolchain_launchers(&launcher_dir, &runfiles, &toolchain)?;
     }
 
-    // Apply any pending user_config edits before dispatching to the
-    // per-IDE runner — that way tests / --dry-run flows (future work)
-    // and the per-IDE runners themselves see a consistent on-disk
-    // state, and running `setup --clippy` with no IDE change still
-    // takes effect.
+    // Apply user_config edits before per-IDE dispatch so the runners
+    // and any --dry-run flow see the same on-disk state.
     apply_user_config_edits(&launcher_dir, pending_clippy, pending_ppw, output_user_root)?;
 
     let ctx = SetupCtx {
@@ -382,14 +352,10 @@ struct SetupCtx {
     toolchain: ToolchainBinaries,
 }
 
-/// Absolute, canonicalized paths to the three toolchain binaries the
-/// launcher shims exec. Resolved once in `main` via setup's own
-/// runfiles + the `*_RLOCATIONPATH` make-vars (baked at compile time
-/// by the `rustc_env` block on setup's BUILD target) + [`fs::canonicalize`]
-/// (escapes the runfiles symlink tree — which lives in `bazel-out` and
-/// would be wiped by `bazel clean` — and lands at the canonical
-/// `output_base/external/...` path that only goes away on
-/// `bazel clean --expunge`).
+/// Absolute canonicalized toolchain paths the launcher shims exec.
+/// Canonicalization escapes the `bazel-out` runfiles symlink tree
+/// (wiped by `bazel clean`) and lands at
+/// `output_base/external/...` (only wiped by `--expunge`).
 struct ToolchainBinaries {
     rust_analyzer: Utf8PathBuf,
     proc_macro_srv: Utf8PathBuf,
@@ -422,18 +388,15 @@ const CODE_WORKSPACE_EXT: &str = ".code-workspace";
 
 const DEFAULT_VSCODE_OUTPUT: &str = ".vscode/settings.json";
 
-/// `settings_json` is always written; `code_workspace` is optional
-/// (autodetected when a unique `.code-workspace` exists at the
-/// workspace root, forced by `--code-workspace`, or skipped by
-/// `--no-code-workspace`). Resolved before install work so
-/// ambiguous-`.code-workspace` errors fail fast.
+/// `settings_json` is always written. `code_workspace` is optional
+/// (autodetected, forced by `--code-workspace`, or skipped by
+/// `--no-code-workspace`). Resolved before install so ambiguity
+/// errors fail fast.
 #[derive(Debug)]
 struct ResolvedVscodeTargets {
     settings_json: Utf8PathBuf,
-    /// When set, the managed keys ALSO get merged into this file
-    /// under [`CodeWorkspaceTarget::settings_key`] (default
-    /// `"settings"` — the block VS Code reads window-scoped
-    /// rust-analyzer config from when opening via the workspace file).
+    /// When set, managed keys are also merged into this file under
+    /// [`CodeWorkspaceTarget::settings_key`] (default `"settings"`).
     code_workspace: Option<CodeWorkspaceTarget>,
 }
 
@@ -616,10 +579,9 @@ fn clean_cache(launcher_dir: &Utf8Path) -> Result<()> {
     }
 }
 
-/// Copy discover + flycheck into `dir`. They live in `bazel-out`
-/// originally and would be wiped by `bazel clean`; the copy survives
-/// until the next `bazel clean --expunge` (which also nukes the
-/// toolchain binaries and requires re-running setup anyway).
+/// Copy discover + flycheck into `dir`. The runfiles originals live
+/// in `bazel-out` and would be wiped by `bazel clean`; copies survive
+/// until `bazel clean --expunge`.
 fn install_source_binaries(dir: &Utf8Path, runfiles: &Runfiles) -> Result<()> {
     fs::create_dir_all(dir).with_context(|| format!("creating directory {dir}"))?;
     for (rlocation, filename) in [
@@ -652,9 +614,8 @@ fn install_toolchain_launchers(
 }
 
 fn write_launcher_paths_json(path: &Utf8Path, toolchain: &ToolchainBinaries) -> Result<()> {
-    // Entirely generated file — no trivia to preserve, so plain
-    // serde_json is fine (unlike the .vscode/settings.json /
-    // .code-workspace merges that go through the CST).
+    // Fully generated — plain serde_json (unlike the CST-merged
+    // settings.json / .code-workspace paths).
     let map = Value::Object(
         LAUNCHER_LOGICAL_NAMES
             .iter()
@@ -687,8 +648,6 @@ fn set_executable(path: &Utf8Path) -> Result<()> {
     let mut perms = fs::metadata(path)
         .with_context(|| format!("stat {path}"))?
         .permissions();
-    // rwxr-xr-x: rust-analyzer (and the user from a shell) must be able
-    // to exec this; group/other read+exec is harmless.
     perms.set_mode(0o755);
     fs::set_permissions(path, perms).with_context(|| format!("chmod {path}"))?;
     Ok(())
@@ -696,21 +655,11 @@ fn set_executable(path: &Utf8Path) -> Result<()> {
 
 #[cfg(not(unix))]
 fn set_executable(_path: &Utf8Path) -> Result<()> {
-    // Windows doesn't use POSIX exec bits; `.bat`/`.exe` extension
-    // is the cue for the OS loader.
     Ok(())
 }
 
-/// Normalize backslashes to forward slashes. Applied to every path we
-/// hand to an editor's config file (settings.json, languages.toml, init.lua,
-/// coc-settings.json).
-///
-/// Why everywhere:
-///   * In JSON / Lua / TOML, `\` is an escape character — Windows-native
-///     paths (`C:\Users\me\...`) embed as invalid escape sequences and
-///     break the parser.
-///   * Modern Windows tooling — VSCode, rust-analyzer, bazel.exe — all
-///     accept forward slashes universally.
+/// Normalize backslashes to forward slashes for embedding in editor
+/// config files (JSON/Lua/TOML all treat `\` as an escape).
 fn to_forward_slashes(path: &str) -> String {
     if cfg!(windows) {
         path.replace('\\', "/")
@@ -723,13 +672,10 @@ fn to_forward_slashes(path: &str) -> String {
 // Editor-relative defaults
 // ---------------------------------------------------------------------------
 
-/// Workspace-relative launcher dir for the Vscode subcommand. Pinned
-/// to `.vscode/` regardless of where the settings file lives (default
-/// `.vscode/settings.json`, or a `.code-workspace` at the workspace
-/// root, or a custom `--output` path): `.vscode/` is universally
-/// recognized as VSCode-scoped, and the committed settings file
-/// references `${workspaceFolder}/.vscode/.rules_rust_analyzer/<name>.exe`
-/// so it stays the same no matter what output path the user picked.
+/// Workspace-relative launcher dir for the VSCode subcommand.
+/// Pinned to `.vscode/` regardless of the settings file location so
+/// the committed `${workspaceFolder}/.vscode/.rules_rust_analyzer/...`
+/// reference stays stable.
 const VSCODE_LAUNCHER_REL: &str = ".vscode";
 
 fn launcher_dir_for(workspace: &Utf8Path, ide: &IdeCmd) -> Utf8PathBuf {
@@ -747,23 +693,17 @@ fn launcher_dir_for(workspace: &Utf8Path, ide: &IdeCmd) -> Utf8PathBuf {
 // VSCode settings.json merge
 // ---------------------------------------------------------------------------
 
-/// A managed key/value pair plus how to combine it with whatever the user
-/// already has under that key.
+/// A managed key plus how to combine it with the user's existing value.
 enum ManagedValue {
-    /// Overwrite the whole key — appropriate for scalar / object-shaped
-    /// keys like `rust-analyzer.server.path` where the rules_rust value is
-    /// the canonical one and stale entries should be replaced.
+    /// Overwrite the whole key.
     Replace(Value),
-    /// Dict-merge: ensure the key is an object containing the listed
-    /// sub-entries. If the user already has a value for a given glob
-    /// pattern we leave it alone — including explicit `false` overrides —
-    /// so they can opt out of any individual exclude by setting it to
-    /// `false` rather than deleting the entry (which we'd just add back).
+    /// Dict-merge: add the listed sub-entries. Existing keys under
+    /// the same glob are preserved (including explicit `false`) so
+    /// users can opt out of individual excludes.
     InsertEntries(Vec<(String, Value)>),
 }
 
-/// VS Code expands `${workspaceFolder}` for rust-analyzer's path
-/// settings — that's what keeps the committed settings file portable.
+/// `${workspaceFolder}` keeps the committed settings file portable.
 /// Kept in sync with [`launcher_dir_for`]'s VSCode arm via
 /// [`VSCODE_LAUNCHER_REL`].
 fn workspace_relative(filename: &str) -> String {
@@ -775,13 +715,12 @@ fn vscode_managed_keys(ctx: &SetupCtx) -> Vec<(String, ManagedValue)> {
     let pms_path = workspace_relative("rust_analyzer_proc_macro_srv.exe");
     let rustfmt_path = workspace_relative("rustfmt.exe");
     let discover_path = workspace_relative(DISCOVER_BINARY_FILENAME);
+    let flycheck_path = workspace_relative(FLYCHECK_BINARY_FILENAME);
     let bazel_outputs = || vec![(BAZEL_OUTPUTS_GLOB.to_string(), Value::Bool(true))];
-    // Rendered discover command is intentionally identical for every
-    // developer — per-user knobs (clippy, per-package-workspaces) live
-    // in `<launcher_dir>/user_config.json`, not here. `{arg}` is
-    // always present so rust-analyzer will pass the per-file arg on
-    // demand; discover ignores it when the user opted out of
-    // per-package-workspaces.
+    // Command is identical for every developer. Per-user knobs (clippy,
+    // per-package-workspaces) live in the launcher-dir user_config, not
+    // here. `{arg}` is always present; discover ignores it in
+    // whole-workspace mode.
     let discover_command = json!([discover_path, "{arg}"]);
     let mut out = vec![
         (
@@ -810,17 +749,20 @@ fn vscode_managed_keys(ctx: &SetupCtx) -> Vec<(String, ManagedValue)> {
         ));
     }
     if !ctx.skip_rustfmt {
-        // overrideCommand is an argv array; the toolchain rustfmt takes
-        // file contents on stdin and writes formatted output to stdout,
-        // which is the contract rust-analyzer expects.
         out.push((
             RUSTFMT_OVERRIDE_KEY.to_string(),
             ManagedValue::Replace(json!([rustfmt_path])),
         ));
     }
-    // Three exclude maps share the same Bazel-outputs glob — dict-merged
-    // so any user entries (other patterns, explicit `false` overrides)
-    // survive untouched.
+    // Prevents RA from running `cargo check` for any auto-detected
+    // `Cargo.toml`. `$saved_file` is RA's substitution — flycheck
+    // resolves the label from it.
+    out.push((
+        CHECK_OVERRIDE_KEY.to_string(),
+        ManagedValue::Replace(json!([flycheck_path, "--saved-file", "$saved_file"])),
+    ));
+    // All three exclude maps get the same glob, dict-merged so any
+    // user entries survive.
     out.push((
         FILES_WATCHER_EXCLUDE_KEY.to_string(),
         ManagedValue::InsertEntries(bazel_outputs()),
@@ -1327,9 +1269,10 @@ mod tests {
         let with_srv = vscode_managed_keys(&ctx);
         ctx.skip_proc_macro_server = true;
         let without_srv = vscode_managed_keys(&ctx);
-        // 4 rust-analyzer keys + 3 exclude maps = 7 total.
-        assert_eq!(with_srv.len(), 7);
-        assert_eq!(without_srv.len(), 6);
+        // 5 rust-analyzer keys (discover, server, proc-macro, rustfmt,
+        // check.overrideCommand) + 3 exclude maps = 8 total.
+        assert_eq!(with_srv.len(), 8);
+        assert_eq!(without_srv.len(), 7);
         assert!(!without_srv.iter().any(|(k, _)| k == PROC_MACRO_SRV_KEY));
     }
 
@@ -1339,11 +1282,12 @@ mod tests {
         let with_fmt = vscode_managed_keys(&ctx);
         ctx.skip_rustfmt = true;
         let without_fmt = vscode_managed_keys(&ctx);
-        assert_eq!(with_fmt.len(), 7);
-        assert_eq!(without_fmt.len(), 6);
+        assert_eq!(with_fmt.len(), 8);
+        assert_eq!(without_fmt.len(), 7);
         assert!(!without_fmt.iter().any(|(k, _)| k == RUSTFMT_OVERRIDE_KEY));
-        // The proc-macro key still rides along.
+        // The proc-macro and check-override keys still ride along.
         assert!(without_fmt.iter().any(|(k, _)| k == PROC_MACRO_SRV_KEY));
+        assert!(without_fmt.iter().any(|(k, _)| k == CHECK_OVERRIDE_KEY));
     }
 
     #[test]
@@ -1445,9 +1389,6 @@ mod tests {
 
     #[test]
     fn apply_user_config_edits_persists_output_user_root() {
-        // `setup --output-user-root /some/path` writes the path into
-        // the launcher-dir user_config, so flycheck picks it up on
-        // future saves without any committed-file change.
         let dir = std::env::temp_dir().join(format!("setup_uc_our_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();

--- a/tools/rust_analyzer/cache.rs
+++ b/tools/rust_analyzer/cache.rs
@@ -43,7 +43,7 @@ const CACHE_DIR_REL_PREFIX: &str = ".rules_rust_analyzer";
 /// unchanged workspace would keep serving JSON assembled by an older
 /// version of the assembler. See the explanatory comment on
 /// `compute_key` for the incident that motivated this.
-const CACHE_SCHEMA_VERSION: u32 = 0;
+const CACHE_SCHEMA_VERSION: u32 = 1;
 
 /// Compute the cache key for an assembled rust-project.json from the raw
 /// spec contents plus every auxiliary input the assembler bakes into its
@@ -53,7 +53,6 @@ const CACHE_SCHEMA_VERSION: u32 = 0;
 ///
 /// `spec_contents` should already be sorted by spec path so the key is
 /// independent of file-system enumeration order.
-#[allow(clippy::too_many_arguments)]
 pub fn compute_key(
     spec_contents: &[(Utf8PathBuf, String)],
     toolchain_info: &str,
@@ -61,7 +60,6 @@ pub fn compute_key(
     workspace: &Utf8Path,
     execution_root: &Utf8Path,
     launcher_dir: &str,
-    clippy: bool,
 ) -> String {
     let mut hasher = DefaultHasher::new();
     CACHE_SCHEMA_VERSION.hash(&mut hasher);
@@ -75,11 +73,6 @@ pub fn compute_key(
     // (vscode→neovim→helix) on the same workspace would silently serve
     // the previously-cached editor's launcher path.
     launcher_dir.hash(&mut hasher);
-    // The Flycheck Runnable's args differ between build-mode and clippy-mode
-    // (`--clippy` prepended). Without this bit in the key, a cached
-    // build-mode project would be served to a clippy-mode setup (or vice
-    // versa) and rust-analyzer would silently keep running the wrong flow.
-    clippy.hash(&mut hasher);
     for (path, content) in spec_contents {
         path.as_str().hash(&mut hasher);
         content.hash(&mut hasher);
@@ -178,8 +171,8 @@ mod tests {
                 String::from("{\"id\":\"b\"}"),
             ),
         ];
-        let k1 = compute_key(&specs, toolchain, bazel, ws, er, "", false);
-        let k2 = compute_key(&specs, toolchain, bazel, ws, er, "", false);
+        let k1 = compute_key(&specs, toolchain, bazel, ws, er, "");
+        let k2 = compute_key(&specs, toolchain, bazel, ws, er, "");
         assert_eq!(k1, k2);
     }
 
@@ -192,8 +185,8 @@ mod tests {
         let base = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         let mutated = vec![(Utf8PathBuf::from("a.json"), "b".to_string())];
         assert_ne!(
-            compute_key(&base, toolchain, bazel, ws, er, "", false),
-            compute_key(&mutated, toolchain, bazel, ws, er, "", false)
+            compute_key(&base, toolchain, bazel, ws, er, ""),
+            compute_key(&mutated, toolchain, bazel, ws, er, "")
         );
     }
 
@@ -204,8 +197,8 @@ mod tests {
         let er = Utf8Path::new("/er");
         let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         assert_ne!(
-            compute_key(&specs, "{\"sysroot\":\"a\"}", bazel, ws, er, "", false),
-            compute_key(&specs, "{\"sysroot\":\"b\"}", bazel, ws, er, "", false),
+            compute_key(&specs, "{\"sysroot\":\"a\"}", bazel, ws, er, ""),
+            compute_key(&specs, "{\"sysroot\":\"b\"}", bazel, ws, er, ""),
         );
     }
 
@@ -215,8 +208,8 @@ mod tests {
         let er = Utf8Path::new("/er");
         let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         assert_ne!(
-            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws1"), er, "", false),
-            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws2"), er, "", false),
+            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws1"), er, ""),
+            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws2"), er, ""),
         );
     }
 
@@ -238,7 +231,6 @@ mod tests {
                 ws,
                 er,
                 "/ws/.vscode/.rules_rust_analyzer",
-                false,
             ),
             compute_key(
                 &specs,
@@ -247,24 +239,7 @@ mod tests {
                 ws,
                 er,
                 "/ws/.helix/.rules_rust_analyzer",
-                false,
             ),
-        );
-    }
-
-    #[test]
-    fn compute_key_changes_with_clippy() {
-        // The flycheck runnable's args differ between clippy and
-        // non-clippy setups — the cache key must distinguish them so a
-        // build-mode cached project can't be served to a clippy-mode
-        // setup (or vice versa).
-        let bazel = Utf8Path::new("/usr/bin/bazel");
-        let ws = Utf8Path::new("/ws");
-        let er = Utf8Path::new("/er");
-        let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
-        assert_ne!(
-            compute_key(&specs, "{}", bazel, ws, er, "", false),
-            compute_key(&specs, "{}", bazel, ws, er, "", true),
         );
     }
 }

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -69,7 +69,6 @@ pub fn generate_rust_project(
     bazel_args: &[String],
     rules_rust_name: &str,
     targets: &[String],
-    clippy: bool,
 ) -> anyhow::Result<RustProject> {
     // Materialize per-crate spec files via the aspect, with Bazel emitting BEP
     // so we can discover them as a side-effect of the build. This replaces a
@@ -126,7 +125,6 @@ pub fn generate_rust_project(
         workspace,
         execution_root,
         &launcher_dir,
-        clippy,
     );
     if let Some(bytes) = cache::get(workspace, &cache_key)? {
         match serde_json::from_slice::<RustProject>(&bytes) {
@@ -151,13 +149,8 @@ pub fn generate_rust_project(
     let crate_specs =
         parse_and_consolidate(&spec_contents, output_base, workspace, execution_root)?;
 
-    let project = rust_project::assemble_rust_project(
-        bazel,
-        workspace,
-        toolchain_info,
-        &crate_specs,
-        clippy,
-    )?;
+    let project =
+        rust_project::assemble_rust_project(bazel, workspace, toolchain_info, &crate_specs)?;
 
     // Surface dep-graph problems the assembler had to paper over (missing
     // deps, cycles). Each becomes a log::warn (visible as a progress event

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -13,43 +13,49 @@ pub use rust_project::{
     assemble_rust_project, diagnose, format_diagnostics, AssemblyDiagnostics, DiscoverProject,
     RustAnalyzerArg,
 };
-use serde::{de::DeserializeOwned, Deserialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 pub use aquery::{consolidate_crate_specs, CrateSpec};
 pub use cache::CACHE_SUBDIR;
+
+/// Written by discover, read by `bin/flycheck.rs`.
+pub const TOOLCHAIN_INFO_SIDECAR: &str = "toolchain_info.json";
+
+/// Every field is `Option` / `default` so a newer flycheck reading
+/// an older sidecar falls back to slow paths instead of failing.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ToolchainInfoSidecar {
+    pub sysroot_src: Utf8PathBuf,
+    #[serde(default)]
+    pub workspace: Option<Utf8PathBuf>,
+    /// Saved-file → label map for flycheck's `--saved-file` mode.
+    /// Missing entries fall back to `bazel query`.
+    #[serde(default)]
+    pub file_labels: BTreeMap<Utf8PathBuf, String>,
+}
 
 pub const WORKSPACE_ROOT_FILE_NAMES: &[&str] =
     &["MODULE.bazel", "REPO.bazel", "WORKSPACE.bazel", "WORKSPACE"];
 
 pub const BUILD_FILE_NAMES: &[&str] = &["BUILD.bazel", "BUILD"];
 
-/// Shared between the setup-side install and the
-/// `rust_project.rs` flycheck-runnable emitter so the two can't
-/// drift on extension handling.
-///
-/// `.exe` on every platform is deliberate: Node spawn (the
-/// rust-analyzer VS Code extension's spawner) can't execute
-/// extensionless files on Windows without `shell: true`, and POSIX
-/// `execve` ignores file extensions — same filename works everywhere.
+/// `.exe` on every platform: Node spawn (the RA VS Code extension)
+/// can't execute extensionless files on Windows without `shell: true`;
+/// POSIX `execve` ignores extensions.
 pub const FLYCHECK_BINARY_FILENAME: &str = "flycheck.exe";
 
 pub const DISCOVER_BINARY_FILENAME: &str = "discover_bazel_rust_project.exe";
 
-/// JSON embedded at compile time. The `:toolchain_info_env` rule
-/// (BUILD.bazel) emits the env var through Bazel's path-mapping-aware
-/// `Args` machinery; routing the same path through a plain
-/// `rustc_env = {"K": "$(execpath …)"}` would miss the path-mapping
-/// rewrite under `--experimental_output_paths=strip` and fail to
-/// locate the file. Content uses `__OUTPUT_BASE__` / `__WORKSPACE__` /
-/// `__EXEC_ROOT__` placeholder tokens substituted at runtime (see
-/// `deserialize_with_substitution`).
+/// Env var wired via the `:toolchain_info_env` rule so the JSON path
+/// goes through Bazel's `Args` (path-mapping-aware); a plain
+/// `rustc_env` `$(execpath ...)` misses the rewrite under
+/// `--experimental_output_paths=strip`. Placeholders resolved by
+/// `deserialize_with_substitution`.
 const TOOLCHAIN_INFO_RAW: &str = include_str!(env!("RUST_ANALYZER_TOOLCHAIN_JSON"));
 
-/// `dirname(current_exe())` — used by discover/flycheck to find their
-/// per-install sibling files (cache dir, output_user_root). Uses
-/// `current_exe` rather than `argv[0]` because the install is a real
-/// `fs::copy`: the runfiles crate's argv[0]-first policy doesn't
-/// apply post-install.
+/// `dirname(current_exe())`. Uses `current_exe` not `argv[0]` because
+/// the install is a real `fs::copy` — the runfiles crate's
+/// argv[0]-first policy doesn't apply post-install.
 pub fn install_dir() -> anyhow::Result<Utf8PathBuf> {
     let exe = std::env::current_exe().context("locating current_exe")?;
     let parent = exe
@@ -70,11 +76,8 @@ pub fn generate_rust_project(
     rules_rust_name: &str,
     targets: &[String],
 ) -> anyhow::Result<RustProject> {
-    // Materialize per-crate spec files via the aspect, with Bazel emitting BEP
-    // so we can discover them as a side-effect of the build. This replaces a
-    // separate `bazel aquery` round-trip — that query is the dominant cost in
-    // a large monorepo (O(action graph) every invocation, never cached) and
-    // dropping it is the main perf win of this path.
+    // Discover specs as a build side-effect via BEP. Replaces a
+    // separate `bazel aquery` — the dominant cost in a large monorepo.
     let bep_file = output_base.join(format!("rules_rust_ra_bep_{}.json", std::process::id()));
     let _bep_cleanup = BepCleanup(bep_file.clone());
 
@@ -91,8 +94,8 @@ pub fn generate_rust_project(
 
     let spec_paths = match bep::parse_spec_paths(&bep_file, execution_root) {
         Ok(paths) => paths,
-        // A failed build often means a missing or partial BEP file; surface
-        // the build error rather than the downstream parse error.
+        // Missing/partial BEP usually means the build failed; surface
+        // that rather than the parse error.
         Err(_) if !build.success => {
             bail!(
                 "bazel build failed and produced no usable output:\n{}",
@@ -109,12 +112,8 @@ pub fn generate_rust_project(
     }
     log::info!("discovered {} crate spec files via BEP", spec_paths.len());
 
-    // Toolchain-info JSON is embedded at compile time — see
-    // `TOOLCHAIN_INFO_RAW` (above) for the wiring.
     let toolchain_info_raw = TOOLCHAIN_INFO_RAW;
 
-    // Read every spec file once; the contents feed both the cache key and the
-    // consolidate/assemble step on a miss.
     let spec_contents = read_specs(&spec_paths)?;
 
     let launcher_dir = std::env::var(cache::LAUNCHER_DIR_ENV_VAR).unwrap_or_default();
@@ -133,8 +132,6 @@ pub fn generate_rust_project(
                 return Ok(project);
             }
             Err(e) => {
-                // A corrupted entry shouldn't block discovery — log, evict, and
-                // fall through to recompute.
                 log::warn!("merge cache entry {cache_key} corrupted ({e}); recomputing");
             }
         }
@@ -149,17 +146,29 @@ pub fn generate_rust_project(
     let crate_specs =
         parse_and_consolidate(&spec_contents, output_base, workspace, execution_root)?;
 
+    // Publish sysroot_src + workspace + saved-file→label map to
+    // `<launcher_dir>/toolchain_info.json`. Flycheck reads this to
+    // un-remap rustc's `/rustc/<sha>/library/...` diagnostic paths,
+    // pick the right workspace root when rust-analyzer spawns it with
+    // cwd inside a package, and skip a `bazel query` when it already
+    // knows which target owns the saved file. Best-effort — a write
+    // failure just means flycheck falls back to the slow paths.
+    if !launcher_dir.is_empty() {
+        write_toolchain_info_sidecar(
+            Utf8Path::new(&launcher_dir),
+            &toolchain_info.sysroot_src,
+            workspace,
+            build_file_label_map(&crate_specs),
+        );
+    }
+
     let project =
         rust_project::assemble_rust_project(bazel, workspace, toolchain_info, &crate_specs)?;
 
-    // Surface dep-graph problems the assembler had to paper over (missing
-    // deps, cycles). Each becomes a log::warn (visible as a progress event
-    // in rust-analyzer's UI) AND lands in a persistent log file so users
-    // can grep after the fact — progress events scroll off the status bar
-    // before anyone notices them.
+    // Log warnings AND persist to disk — progress events scroll off
+    // the status bar before anyone reads them.
     report_diagnostics(workspace, &crate_specs);
 
-    // Best-effort cache write. Failures are logged but don't fail discovery.
     match serde_json::to_vec(&project) {
         Ok(bytes) => cache::put(workspace, &cache_key, &bytes),
         Err(e) => log::warn!("merge cache: serializing project failed ({e}); not caching"),
@@ -170,12 +179,52 @@ pub fn generate_rust_project(
 
 const WARNINGS_LOG_REL: &str = ".vscode/.rules_rust_analyzer/last_warnings.log";
 
+/// Publish sysroot_src, workspace, and the saved-file→label map to
+/// `<launcher_dir>/toolchain_info.json` for flycheck. Best-effort:
+/// a write failure just means flycheck falls back to slow per-save
+/// paths (bazel query, cwd guess).
+fn write_toolchain_info_sidecar(
+    launcher_dir: &Utf8Path,
+    sysroot_src: &Utf8Path,
+    workspace: &Utf8Path,
+    file_labels: BTreeMap<Utf8PathBuf, String>,
+) {
+    let sidecar = ToolchainInfoSidecar {
+        sysroot_src: sysroot_src.to_path_buf(),
+        workspace: Some(workspace.to_path_buf()),
+        file_labels,
+    };
+    let path = launcher_dir.join(TOOLCHAIN_INFO_SIDECAR);
+    match serde_json::to_vec(&sidecar) {
+        Ok(bytes) => {
+            if let Err(e) = fs::write(&path, &bytes) {
+                log::warn!("toolchain_info sidecar: writing {path}: {e}");
+            }
+        }
+        Err(e) => log::warn!("toolchain_info sidecar: serializing failed: {e}"),
+    }
+}
+
+/// Map each spec's `root_module` to its label. Multi-file siblings
+/// fall back to `bazel query`.
+fn build_file_label_map(
+    crate_specs: &std::collections::BTreeSet<CrateSpec>,
+) -> BTreeMap<Utf8PathBuf, String> {
+    let mut out = BTreeMap::new();
+    for spec in crate_specs {
+        let Some(build) = spec.build.as_ref() else {
+            continue;
+        };
+        out.insert(Utf8PathBuf::from(&spec.root_module), build.label.clone());
+    }
+    out
+}
+
 fn report_diagnostics(workspace: &Utf8Path, crate_specs: &std::collections::BTreeSet<CrateSpec>) {
     let diag = rust_project::diagnose(crate_specs);
     let log_path = workspace.join(WARNINGS_LOG_REL);
     if diag.is_empty() {
-        // Clear any leftover file from a previous run so absence-of-file is
-        // a meaningful "no diagnostics this round" signal.
+        // Absence-of-file signals "clean this round".
         let _ = fs::remove_file(&log_path);
         return;
     }

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -21,6 +21,21 @@ pub use cache::CACHE_SUBDIR;
 /// Written by discover, read by `bin/flycheck.rs`.
 pub const TOOLCHAIN_INFO_SIDECAR: &str = "toolchain_info.json";
 
+/// Suffix appended to the outer server's `output_base` to derive the
+/// flycheck server's own `--output_base` sibling. Kept as a shared
+/// constant so `flycheck.rs`'s derivation and `setup.rs`'s
+/// `--clean --expunge` target can never drift out of sync.
+pub const RRA_OUTPUT_BASE_SUFFIX: &str = "_rra";
+
+/// The `--output_base` flycheck should use given the outer server's
+/// `output_base`. Both bases live under the same `output_user_root`
+/// and share its `install/` extraction.
+pub fn flycheck_output_base(outer: &Utf8Path) -> Utf8PathBuf {
+    let mut sibling = outer.as_str().to_owned();
+    sibling.push_str(RRA_OUTPUT_BASE_SUFFIX);
+    Utf8PathBuf::from(sibling)
+}
+
 /// Every field is `Option` / `default` so a newer flycheck reading
 /// an older sidecar falls back to slow paths instead of failing.
 #[derive(Debug, Serialize, Deserialize)]
@@ -28,10 +43,82 @@ pub struct ToolchainInfoSidecar {
     pub sysroot_src: Utf8PathBuf,
     #[serde(default)]
     pub workspace: Option<Utf8PathBuf>,
+    /// The outer Bazel server's `output_base` at the time discover
+    /// last ran. Flycheck uses `<output_base>_rra` as its own
+    /// `--output_base`, so the flycheck server sits next to the user's
+    /// primary server and shares its `install/` extraction while still
+    /// holding a distinct server lock.
+    #[serde(default)]
+    pub output_base: Option<Utf8PathBuf>,
     /// Saved-file → label map for flycheck's `--saved-file` mode.
     /// Missing entries fall back to `bazel query`.
     #[serde(default)]
     pub file_labels: BTreeMap<Utf8PathBuf, String>,
+}
+
+/// Cached `bazel info` snapshot against flycheck's dedicated server.
+/// Setup pre-populates on install (one `bazel info` per setup run);
+/// flycheck reads and refreshes only when the cache key (`output_base`)
+/// no longer matches the currently-derived flycheck output_base — so
+/// on the steady-state clippy path, saves cost zero bazel invocations.
+///
+/// Shape mirrors `tools/vscode/src/lib.rs::BazelInfo` (intentionally
+/// duplicated so the two tools stay decoupled), plus `execution_root`
+/// which flycheck needs to resolve BEP-relative clippy output paths
+/// (rules_rust#4130).
+pub const BAZEL_INFO_FILENAME: &str = "bazel_info.json";
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BazelInfo {
+    pub output_base: Utf8PathBuf,
+    pub workspace: Utf8PathBuf,
+    pub execution_root: Utf8PathBuf,
+}
+
+impl BazelInfo {
+    /// Populate by invoking `bazel info` once against the server at
+    /// `output_base` (typically flycheck's `_rra` base). Fails if
+    /// `bazel info` doesn't return all three expected fields — that
+    /// would leave `execution_root` unresolvable and the clippy path
+    /// silently broken.
+    pub fn try_new(
+        bazel: &Utf8Path,
+        workspace: &Utf8Path,
+        output_base: &Utf8Path,
+    ) -> anyhow::Result<Self> {
+        let mut info = bazel_info(bazel, Some(workspace), Some(output_base), &[], &[])
+            .context("bazel info for flycheck server cache")?;
+        Ok(Self {
+            output_base: info
+                .remove("output_base")
+                .context("`bazel info` returned no `output_base` line")?
+                .into(),
+            workspace: info
+                .remove("workspace")
+                .context("`bazel info` returned no `workspace` line")?
+                .into(),
+            execution_root: info
+                .remove("execution_root")
+                .context("`bazel info` returned no `execution_root` line")?
+                .into(),
+        })
+    }
+
+    /// Read the cache; missing / malformed → `None`.
+    pub fn load(launcher_dir: &Utf8Path) -> Option<Self> {
+        let path = launcher_dir.join(BAZEL_INFO_FILENAME);
+        let bytes = fs::read(&path).ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+
+    /// Best-effort persist; a write failure just means the next
+    /// consumer refreshes from `bazel info` again.
+    pub fn save(&self, launcher_dir: &Utf8Path) {
+        let path = launcher_dir.join(BAZEL_INFO_FILENAME);
+        if let Ok(bytes) = serde_json::to_vec(self) {
+            let _ = fs::write(&path, &bytes);
+        }
+    }
 }
 
 pub const WORKSPACE_ROOT_FILE_NAMES: &[&str] =
@@ -146,18 +233,20 @@ pub fn generate_rust_project(
     let crate_specs =
         parse_and_consolidate(&spec_contents, output_base, workspace, execution_root)?;
 
-    // Publish sysroot_src + workspace + saved-file→label map to
-    // `<launcher_dir>/toolchain_info.json`. Flycheck reads this to
-    // un-remap rustc's `/rustc/<sha>/library/...` diagnostic paths,
+    // Publish sysroot_src + workspace + output_base + saved-file→label
+    // map to `<launcher_dir>/toolchain_info.json`. Flycheck reads this
+    // to un-remap rustc's `/rustc/<sha>/library/...` diagnostic paths,
     // pick the right workspace root when rust-analyzer spawns it with
-    // cwd inside a package, and skip a `bazel query` when it already
-    // knows which target owns the saved file. Best-effort — a write
-    // failure just means flycheck falls back to the slow paths.
+    // cwd inside a package, derive its `<output_base>_rra` server
+    // location, and skip a `bazel query` when it already knows which
+    // target owns the saved file. Best-effort — a write failure just
+    // means flycheck falls back to the slow paths.
     if !launcher_dir.is_empty() {
         write_toolchain_info_sidecar(
             Utf8Path::new(&launcher_dir),
             &toolchain_info.sysroot_src,
             workspace,
+            output_base,
             build_file_label_map(&crate_specs),
         );
     }
@@ -179,19 +268,21 @@ pub fn generate_rust_project(
 
 const WARNINGS_LOG_REL: &str = ".vscode/.rules_rust_analyzer/last_warnings.log";
 
-/// Publish sysroot_src, workspace, and the saved-file→label map to
-/// `<launcher_dir>/toolchain_info.json` for flycheck. Best-effort:
-/// a write failure just means flycheck falls back to slow per-save
-/// paths (bazel query, cwd guess).
+/// Publish sysroot_src, workspace, output_base, and the saved-file→
+/// label map to `<launcher_dir>/toolchain_info.json` for flycheck.
+/// Best-effort: a write failure just means flycheck falls back to
+/// slow per-save paths (bazel query, cwd guess, `bazel info output_base`).
 fn write_toolchain_info_sidecar(
     launcher_dir: &Utf8Path,
     sysroot_src: &Utf8Path,
     workspace: &Utf8Path,
+    output_base: &Utf8Path,
     file_labels: BTreeMap<Utf8PathBuf, String>,
 ) {
     let sidecar = ToolchainInfoSidecar {
         sysroot_src: sysroot_src.to_path_buf(),
         workspace: Some(workspace.to_path_buf()),
+        output_base: Some(output_base.to_path_buf()),
         file_labels,
     };
     let path = launcher_dir.join(TOOLCHAIN_INFO_SIDECAR);
@@ -373,7 +464,7 @@ fn assess_discovery(success: bool, spec_count: usize, stderr: &str) -> anyhow::R
     }
 }
 
-fn bazel_command(
+pub fn bazel_command(
     bazel: &Utf8Path,
     workspace: Option<&Utf8Path>,
     output_base: Option<&Utf8Path>,
@@ -476,6 +567,18 @@ mod tests {
         assert_eq!(dir_to_bazel_package(""), "");
         // Mixed (defense in depth).
         assert_eq!(dir_to_bazel_package(r"a/b\c/d"), "a/b/c/d");
+    }
+
+    #[test]
+    fn flycheck_output_base_appends_suffix_at_leaf() {
+        // Sibling must land under the same output_user_root parent so
+        // the two servers share `install/`. Appending to the leaf is
+        // the whole point — a trailing slash would push us into a
+        // subdirectory instead.
+        assert_eq!(
+            flycheck_output_base(Utf8Path::new("/home/u/.cache/bazel/_bazel_u/abc123")),
+            Utf8PathBuf::from("/home/u/.cache/bazel/_bazel_u/abc123_rra"),
+        );
     }
 
     #[test]

--- a/tools/rust_analyzer/rust_project.rs
+++ b/tools/rust_analyzer/rust_project.rs
@@ -294,12 +294,9 @@ fn supports_test_mod(version: &str) -> bool {
     matches!((parts.next(), parts.next()), (Some(major), Some(minor)) if (major, minor) >= (1, 96))
 }
 
-/// `$RULES_RUST_RA_LAUNCHER_DIR` is published by discover's
-/// `self_locate_config`. When unset (discover ran outside a setup
-/// install — direct exec for debugging) we fall back to the
-/// editor-agnostic `<workspace>/.rules_rust_analyzer/`; vscode/helix
-/// users who bypass setup get a stale path, same as every other
-/// fallback in this file.
+/// Prefers `$RULES_RUST_RA_LAUNCHER_DIR` (published by discover's
+/// `self_locate_config`). Falls back to
+/// `<workspace>/.rules_rust_analyzer/` for direct-exec debugging.
 fn flycheck_launcher_path(workspace: &Utf8Path) -> Utf8PathBuf {
     let launcher_dir = std::env::var("RULES_RUST_RA_LAUNCHER_DIR")
         .ok()
@@ -488,13 +485,8 @@ pub fn assemble_rust_project(
             cwd: workspace.to_owned(),
             kind: RunnableKind::Check,
         },
-        // On-save flycheck. rust-analyzer substitutes `{label}` with
-        // the saved file's owning crate and runs the binary; the
-        // binary spawns `bazel build` for that label with rustc
-        // diagnostics enabled, harvests the resulting .rustc-output
-        // files via BEP, and streams their JSON to stdout for
-        // rust-analyzer to parse into squiggles. Args stay user-
-        // agnostic; per-user preferences (clippy, ...) live in
+        // On-save flycheck. Args stay user-agnostic — per-user
+        // preferences (clippy, ...) live in
         // `<launcher_dir>/user_config.json` and are read by
         // `bin/flycheck.rs` on each save.
         Runnable {

--- a/tools/rust_analyzer/rust_project.rs
+++ b/tools/rust_analyzer/rust_project.rs
@@ -478,22 +478,8 @@ pub fn assemble_rust_project(
     workspace: &Utf8Path,
     toolchain_info: ToolchainInfo,
     crate_specs: &BTreeSet<CrateSpec>,
-    clippy: bool,
 ) -> anyhow::Result<RustProject> {
     let emit_test_mod = supports_test_mod(&toolchain_info.version);
-
-    // The flycheck launcher forwards positional args verbatim to the
-    // flycheck binary. `--clippy` opts into concatenating clippy JSON
-    // alongside rustc's — see `bin/flycheck.rs`. Order matters: clap
-    // treats leading `--foo` before positionals as flags, and putting
-    // it before `{label}` keeps the `--` clean when the label needs
-    // shell-escaping.
-    let mut flycheck_args = Vec::new();
-    if clippy {
-        flycheck_args.push("--clippy".to_owned());
-    }
-    flycheck_args.push("{label}".to_owned());
-    flycheck_args.push("{saved_file}".to_owned());
 
     let mut runnables = vec![
         Runnable {
@@ -507,10 +493,13 @@ pub fn assemble_rust_project(
         // binary spawns `bazel build` for that label with rustc
         // diagnostics enabled, harvests the resulting .rustc-output
         // files via BEP, and streams their JSON to stdout for
-        // rust-analyzer to parse into squiggles.
+        // rust-analyzer to parse into squiggles. Args stay user-
+        // agnostic; per-user preferences (clippy, ...) live in
+        // `<launcher_dir>/user_config.json` and are read by
+        // `bin/flycheck.rs` on each save.
         Runnable {
             program: flycheck_launcher_path(workspace).to_string(),
-            args: flycheck_args,
+            args: vec!["{label}".to_owned(), "{saved_file}".to_owned()],
             cwd: workspace.to_owned(),
             kind: RunnableKind::Flycheck,
         },
@@ -705,7 +694,6 @@ mod tests {
                 is_test: false,
                 build: None,
             }]),
-            false,
         )
         .expect("expect success");
 
@@ -780,7 +768,6 @@ mod tests {
                     build: None,
                 },
             ]),
-            false,
         )
         .expect("expect success");
 
@@ -832,7 +819,6 @@ mod tests {
                 version: String::new(),
             },
             &BTreeSet::from([spec("ID-a", &["ID-b"]), spec("ID-b", &["ID-a"])]),
-            false,
         )
         .expect("cycle must not fail assembly");
 
@@ -866,7 +852,6 @@ mod tests {
                 version: String::new(),
             },
             &BTreeSet::from([spec("ID-a", &["ID-nonexistent"])]),
-            false,
         )
         .expect("missing dep must not fail assembly");
 
@@ -874,8 +859,13 @@ mod tests {
         assert_eq!(project.crates[0].deps.len(), 0);
     }
 
+    /// The runnable command must be byte-identical across users regardless
+    /// of clippy preference — flycheck reads its own per-user opt-in from
+    /// `user_config.json` on each save. If this ever regresses to
+    /// per-user command args, the CLI contract with `bin/flycheck.rs`
+    /// silently breaks (clap rejects unknown flags at runtime).
     #[test]
-    fn flycheck_runnable_gets_clippy_flag_when_enabled() {
+    fn flycheck_runnable_uses_positional_args_only() {
         let project = assemble_rust_project(
             Utf8Path::new("bazel"),
             Utf8Path::new("workspace"),
@@ -885,40 +875,6 @@ mod tests {
                 version: String::new(),
             },
             &BTreeSet::from([spec("ID-a", &[])]),
-            true,
-        )
-        .expect("expect success");
-
-        // Under clippy mode the Flycheck runnable prepends `--clippy`
-        // ahead of the `{label}` / `{saved_file}` positional args so
-        // the flycheck binary switches to clippy-aspect mode.
-        let flycheck = project
-            .runnables
-            .iter()
-            .find(|r| matches!(r.kind, RunnableKind::Flycheck))
-            .expect("flycheck runnable must exist");
-        assert_eq!(
-            flycheck.args,
-            vec![
-                "--clippy".to_owned(),
-                "{label}".to_owned(),
-                "{saved_file}".to_owned()
-            ],
-        );
-    }
-
-    #[test]
-    fn flycheck_runnable_omits_clippy_flag_by_default() {
-        let project = assemble_rust_project(
-            Utf8Path::new("bazel"),
-            Utf8Path::new("workspace"),
-            ToolchainInfo {
-                sysroot: "sysroot".to_owned().into(),
-                sysroot_src: "sysroot_src".to_owned().into(),
-                version: String::new(),
-            },
-            &BTreeSet::from([spec("ID-a", &[])]),
-            false,
         )
         .expect("expect success");
 

--- a/tools/rust_analyzer/user_config.rs
+++ b/tools/rust_analyzer/user_config.rs
@@ -1,20 +1,8 @@
 //! Per-user, per-workspace runtime settings for the rust-analyzer
-//! integration.
-//!
-//! Rendered into `<launcher_dir>/user_config.json`. This file lives
-//! inside the launcher dir (e.g. `.vscode/.rules_rust_analyzer/`),
-//! which is gitignored — so nothing here leaks into the shared
-//! `settings.json` / `.code-workspace`. `setup`'s CLI flags mutate
-//! the file; `discover` and `flycheck` read it on every invocation.
-//!
-//! Deliberately serialized as PRETTY JSON (with a trailing newline)
-//! so users editing the file by hand see one key per line and can
-//! diff it sanely if they check it in on a fork.
-//!
-//! `load` treats a missing file as all-defaults; a malformed file
-//! also falls back to defaults with a warning, since blowing up the
-//! LSP over a syntax error the user can't see in their editor is a
-//! worse experience than "clippy silently didn't turn on".
+//! integration. Lives in `<launcher_dir>/user_config.json` (inside
+//! the gitignored launcher dir). `setup` writes it; `discover` and
+//! `flycheck` read it. Malformed → defaults + warning, so an
+//! unreadable file doesn't blow up the LSP.
 
 use std::fs;
 
@@ -25,30 +13,37 @@ use serde::{Deserialize, Serialize};
 /// Filename inside `<launcher_dir>` that holds the per-user config.
 pub const USER_CONFIG_FILENAME: &str = "user_config.json";
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+impl Default for UserConfig {
+    fn default() -> Self {
+        Self {
+            clippy: false,
+            // Whole-workspace mode blew RA memory to 46 GB on a
+            // 713-crate workspace; per-package keeps it cargo-scoped.
+            per_package_workspaces: true,
+            output_user_root: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct UserConfig {
-    /// Run clippy on save and stream its JSON diagnostics alongside
-    /// rustc's. See `bin/flycheck.rs`.
+    /// Run clippy on save alongside rustc. See `bin/flycheck.rs`.
     pub clippy: bool,
 
-    /// Ask discover to focus on the saved file's package instead of
-    /// re-emitting the whole workspace. See the `--per-package-workspaces`
-    /// docs in `bin/setup.rs`.
+    /// Focus discover on the saved file's package instead of the whole
+    /// workspace. See `Default` for why this defaults to `true`.
     pub per_package_workspaces: bool,
 
-    /// Override for flycheck's inner `--output_user_root`. Escape
-    /// hatch for platform-specific concerns (Windows MAX_PATH, atypical
-    /// cache layouts) — `None` lets `bin/flycheck.rs` pick a per-
-    /// workspace directory next to Bazel's normal cache. The
-    /// `--output_user_root` CLI flag on flycheck still wins over this
-    /// for one-off overrides.
+    /// Override for flycheck's `--output_user_root`. `None` picks a
+    /// per-workspace directory next to Bazel's normal cache. The
+    /// `--output_user_root` CLI flag wins for one-off overrides.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_user_root: Option<Utf8PathBuf>,
 }
 
-/// Read `<launcher_dir>/user_config.json`. Missing → defaults;
-/// malformed → defaults + warning (see module docs for rationale).
+/// Read `<launcher_dir>/user_config.json`. Missing or malformed →
+/// defaults (with a warning for malformed).
 pub fn load(launcher_dir: &Utf8Path) -> UserConfig {
     let path = launcher_dir.join(USER_CONFIG_FILENAME);
     let text = match fs::read_to_string(&path) {
@@ -68,9 +63,8 @@ pub fn load(launcher_dir: &Utf8Path) -> UserConfig {
     }
 }
 
-/// Write `<launcher_dir>/user_config.json`. Creates the launcher
-/// dir if it's missing (setup does that too, but this keeps `save`
-/// safe to call in isolation from tests).
+/// Write `<launcher_dir>/user_config.json`, creating the launcher
+/// dir if it's missing.
 pub fn save(launcher_dir: &Utf8Path, config: &UserConfig) -> Result<()> {
     fs::create_dir_all(launcher_dir)
         .with_context(|| format!("creating launcher dir {launcher_dir}"))?;
@@ -84,9 +78,7 @@ pub fn save(launcher_dir: &Utf8Path, config: &UserConfig) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    // Edition 2018 doesn't put `TryFrom` in the prelude, but the tests
-    // use `Utf8PathBuf::try_from` to convert `std::path::PathBuf`
-    // returned by `std::env::temp_dir()`.
+    // Edition 2018 doesn't put `TryFrom` in the prelude.
     use std::convert::TryFrom;
 
     use super::*;
@@ -108,10 +100,8 @@ mod tests {
         let dir = tmp_dir("missing");
         let config = load(&dir);
         assert_eq!(config, UserConfig::default());
-        // Sanity: defaults must be all-false so first-run users don't
-        // implicitly opt into anything.
         assert!(!config.clippy);
-        assert!(!config.per_package_workspaces);
+        assert!(config.per_package_workspaces);
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -131,9 +121,7 @@ mod tests {
 
     #[test]
     fn absent_output_user_root_stays_none() {
-        // `skip_serializing_if` keeps the key out of the file so the
-        // default JSON stays minimal. Round-tripping a `None` produces
-        // a file with no `output_user_root` field.
+        // `skip_serializing_if` keeps the key out of the default file.
         let dir = tmp_dir("absent_output_user_root");
         save(&dir, &UserConfig::default()).unwrap();
         let text = fs::read_to_string(dir.join(USER_CONFIG_FILENAME)).unwrap();
@@ -156,12 +144,27 @@ mod tests {
 
     #[test]
     fn partial_file_uses_defaults_for_missing_keys() {
-        // Forward-compat: an older file that only has `clippy` set
-        // must not fail when a new key is added.
+        // Older file that only has `clippy` set must not fail when a
+        // new key is added, and picks up the new default.
         let dir = tmp_dir("partial");
         fs::write(dir.join(USER_CONFIG_FILENAME), br#"{"clippy": true}"#).unwrap();
         let config = load(&dir);
         assert!(config.clippy);
+        assert!(config.per_package_workspaces);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn explicit_false_in_file_is_preserved() {
+        // `--no-per-package-workspaces` written before the default
+        // flipped must still deserialize as `false`.
+        let dir = tmp_dir("explicit_false");
+        fs::write(
+            dir.join(USER_CONFIG_FILENAME),
+            br#"{"per_package_workspaces": false}"#,
+        )
+        .unwrap();
+        let config = load(&dir);
         assert!(!config.per_package_workspaces);
         let _ = fs::remove_dir_all(&dir);
     }

--- a/tools/rust_analyzer/user_config.rs
+++ b/tools/rust_analyzer/user_config.rs
@@ -20,7 +20,7 @@ impl Default for UserConfig {
             // Whole-workspace mode blew RA memory to 46 GB on a
             // 713-crate workspace; per-package keeps it cargo-scoped.
             per_package_workspaces: true,
-            output_user_root: None,
+            output_base: None,
         }
     }
 }
@@ -35,11 +35,13 @@ pub struct UserConfig {
     /// workspace. See `Default` for why this defaults to `true`.
     pub per_package_workspaces: bool,
 
-    /// Override for flycheck's `--output_user_root`. `None` picks a
-    /// per-workspace directory next to Bazel's normal cache. The
-    /// `--output_user_root` CLI flag wins for one-off overrides.
+    /// Override for flycheck's `--output_base`. `None` derives the
+    /// server location from the sidecar's `output_base` with an
+    /// `_rra` suffix, so flycheck's server sits next to the primary
+    /// one under the same `output_user_root`. The `--output_base` CLI
+    /// flag wins for one-off overrides.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub output_user_root: Option<Utf8PathBuf>,
+    pub output_base: Option<Utf8PathBuf>,
 }
 
 /// Read `<launcher_dir>/user_config.json`. Missing or malformed →
@@ -111,7 +113,7 @@ mod tests {
         let original = UserConfig {
             clippy: true,
             per_package_workspaces: true,
-            output_user_root: Some(Utf8PathBuf::from("/tmp/custom_flycheck_root")),
+            output_base: Some(Utf8PathBuf::from("/tmp/custom_flycheck_base")),
         };
         save(&dir, &original).unwrap();
         let loaded = load(&dir);
@@ -120,13 +122,13 @@ mod tests {
     }
 
     #[test]
-    fn absent_output_user_root_stays_none() {
+    fn absent_output_base_stays_none() {
         // `skip_serializing_if` keeps the key out of the default file.
-        let dir = tmp_dir("absent_output_user_root");
+        let dir = tmp_dir("absent_output_base");
         save(&dir, &UserConfig::default()).unwrap();
         let text = fs::read_to_string(dir.join(USER_CONFIG_FILENAME)).unwrap();
         assert!(
-            !text.contains("output_user_root"),
+            !text.contains("output_base"),
             "unset field should be omitted, got:\n{}",
             text,
         );

--- a/tools/rust_analyzer/user_config.rs
+++ b/tools/rust_analyzer/user_config.rs
@@ -19,7 +19,7 @@
 use std::fs;
 
 use anyhow::{Context, Result};
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Serialize};
 
 /// Filename inside `<launcher_dir>` that holds the per-user config.
@@ -36,6 +36,15 @@ pub struct UserConfig {
     /// re-emitting the whole workspace. See the `--per-package-workspaces`
     /// docs in `bin/setup.rs`.
     pub per_package_workspaces: bool,
+
+    /// Override for flycheck's inner `--output_user_root`. Escape
+    /// hatch for platform-specific concerns (Windows MAX_PATH, atypical
+    /// cache layouts) — `None` lets `bin/flycheck.rs` pick a per-
+    /// workspace directory next to Bazel's normal cache. The
+    /// `--output_user_root` CLI flag on flycheck still wins over this
+    /// for one-off overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_user_root: Option<Utf8PathBuf>,
 }
 
 /// Read `<launcher_dir>/user_config.json`. Missing → defaults;
@@ -112,10 +121,27 @@ mod tests {
         let original = UserConfig {
             clippy: true,
             per_package_workspaces: true,
+            output_user_root: Some(Utf8PathBuf::from("/tmp/custom_flycheck_root")),
         };
         save(&dir, &original).unwrap();
         let loaded = load(&dir);
         assert_eq!(loaded, original);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn absent_output_user_root_stays_none() {
+        // `skip_serializing_if` keeps the key out of the file so the
+        // default JSON stays minimal. Round-tripping a `None` produces
+        // a file with no `output_user_root` field.
+        let dir = tmp_dir("absent_output_user_root");
+        save(&dir, &UserConfig::default()).unwrap();
+        let text = fs::read_to_string(dir.join(USER_CONFIG_FILENAME)).unwrap();
+        assert!(
+            !text.contains("output_user_root"),
+            "unset field should be omitted, got:\n{}",
+            text,
+        );
         let _ = fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Implements https://github.com/bazelbuild/rules_rust/pull/4143 and also fixes a memory leak from multiple rust-analyzer processes for different rust-analyzer-workspaces.

closes https://github.com/bazelbuild/rules_rust/pull/4143