### PR TITLE
Point CARGO_MANIFEST_DIR to transformed sources dir

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1077,10 +1077,23 @@ def construct_arguments(
         process_wrapper_flags.add("--volatile-status-file", ctx.version_file)
         process_wrapper_flags.add("--stable-status-file", ctx.info_file)
 
-    # Both ctx.label.workspace_root and ctx.label.package are relative paths
-    # and either can be empty strings. Avoid trailing/double slashes in the path.
-    components = "${{pwd}}/{}/{}".format(ctx.label.workspace_root, ctx.label.package).split("/")
-    env["CARGO_MANIFEST_DIR"] = "/".join([c for c in components if c])
+    if crate_info.root.is_source:
+        # Both ctx.label.workspace_root and ctx.label.package are relative paths
+        # and either can be empty strings. Avoid trailing/double slashes in the path.
+        components = "${{pwd}}/{}/{}".format(ctx.label.workspace_root, ctx.label.package).split("/")
+        env["CARGO_MANIFEST_DIR"] = "/".join([c for c in components if c])
+    else:
+        # transform_sources stages source inputs and compile_data under the binary
+        # output tree whenever the crate has a generated input. Keep the manifest
+        # directory next to those transformed inputs so proc macros can find them.
+        # Derive the directory from a File so Bazel can apply path mapping.
+        process_wrapper_flags.add_all(
+            [crate_info.output],
+            before_each = "--subst",
+            format_each = "cargo_manifest_dir=%s",
+            map_each = _get_dirname,
+        )
+        env["CARGO_MANIFEST_DIR"] = "${pwd}/${cargo_manifest_dir}"
 
     if out_dir != None:
         # Hand `OUT_DIR` to `process_wrapper` as an explicit

--- a/test/build_env/BUILD.bazel
+++ b/test/build_env/BUILD.bazel
@@ -1,10 +1,29 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//rust:defs.bzl", "rust_library", "rust_test")
+
+write_file(
+    name = "generated_manifest_dir_source",
+    out = "tests/generated.rs",
+    content = ["pub fn value() -> i32 { 42 }"],
+)
 
 rust_test(
     name = "conflicting_deps_test",
     srcs = ["tests/manifest_dir.rs"],
     compile_data = ["src/manifest_dir_file.txt"],
     edition = "2018",
+)
+
+rust_test(
+    name = "generated_src_manifest_dir_test",
+    srcs = [
+        "tests/generated_manifest_dir.rs",
+        ":generated_manifest_dir_source",
+    ],
+    compile_data = ["src/manifest_dir_file.txt"],
+    crate_root = "tests/generated_manifest_dir.rs",
+    edition = "2018",
+    tags = ["norustfmt"],
 )
 
 rust_library(

--- a/test/build_env/tests/generated_manifest_dir.rs
+++ b/test/build_env/tests/generated_manifest_dir.rs
@@ -1,0 +1,13 @@
+mod generated;
+
+#[test]
+pub fn test_generated_src_manifest_dir() {
+    let actual = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/manifest_dir_file.txt"
+    ))
+    .trim_end();
+    let expected = "This file tests that CARGO_MANIFEST_DIR is set for the build environment";
+    assert_eq!(actual, expected);
+    assert_eq!(generated::value(), 42);
+}


### PR DESCRIPTION
Crates with generated inputs have their source files and compile data staged under bazel-out so rustc can resolve modules from one root. The compile action still points `CARGO_MANIFEST_DIR` at the source package, which is absent from the sandbox and breaks proc macros that read files relative to the manifest.

Assisted-by: GPT-5.6 Sol