### PR TITLE
Reexport output groups for rustfmt and clippy tests

### DIFF
--- a/docs/rust_clippy.vm
+++ b/docs/rust_clippy.vm
@@ -30,27 +30,3 @@ the upstream implementation of clippy, this file must be named either `.clippy.t
 ```text
 build --@rules_rust//rust/settings:clippy.toml=//:clippy.toml
 ```
-
-#[[
-### Running clippy over a tree of targets as a test
-]]#
-
-`rust_clippy_test` is a `test = True` rule that runs clippy over the targets you list and
-transitively across their `deps`, `proc_macro_deps`, and `crate`. The clippy actions run
-during the build phase, so any clippy failure fails `bazel test` before the test executable
-is invoked. The test itself simply prints the paths of the collected clippy marker files.
-
-This is the recommended way to enforce clippy in CI without wiring up `--aspects` /
-`--output_groups` flags.
-
-```python
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy_test", "rust_library")
-
-rust_library(name = "lib", srcs = ["src/lib.rs"], edition = "2021")
-rust_binary(name = "app", srcs = ["src/main.rs"], edition = "2021", deps = [":lib"])
-
-rust_clippy_test(
-    name = "clippy_tree_test",
-    targets = [":app"],
-)
-```

--- a/docs/rust_fmt.vm
+++ b/docs/rust_fmt.vm
@@ -39,37 +39,6 @@ file is used whenever `rustfmt` is run:
 build --@rules_rust//rust/settings:rustfmt.toml=//:rustfmt.toml
 ```
 
-#[[
-### Running rustfmt over a tree of targets as a test
-]]#
-
-`rustfmt_test` runs `rustfmt --check` over a set of Rust targets. By default it walks each
-listed target's `deps`, `proc_macro_deps`, and `crate` transitively, so listing a top-level
-target formats its whole crate graph. Set `transitive = False` to check only the exact targets
-listed. An optional `platform` attribute transitions `targets` to the given platform.
-
-The rustfmt actions run during the build phase, so any formatting failure fails `bazel test`
-before the test executable is invoked. The test itself simply prints the paths of the collected
-`.rustfmt.ok` marker files.
-
-```python
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rustfmt_test")
-
-rust_library(name = "lib", srcs = ["src/lib.rs"], edition = "2021")
-rust_binary(name = "app", srcs = ["src/main.rs"], edition = "2021", deps = [":lib"])
-
-rustfmt_test(
-    name = "fmt_tree_test",
-    targets = [":app"],
-)
-
-rustfmt_test(
-    name = "fmt_app_only_test",
-    targets = [":app"],
-    transitive = False,
-)
-```
-
 [rustfmt]: https://github.com/rust-lang/rustfmt#readme
 [rsg]: https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md
 [rfcp]: https://github.com/rust-lang-nursery/fmt-rfcs

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -463,7 +463,7 @@ RustClippyTestInfo = provider(
     doc = "Clippy check outputs collected by `rust_clippy_test` from the underlying `rust_clippy_aspect`.",
     fields = {
         "checks": "depset[File]: Clippy markers for the visited target plus every crate reached via `deps`, `proc_macro_deps`, and `crate`.",
-        "direct_markers": "list[File]: Clippy markers for the visited target only.",
+        "direct": "depset[File]: Clippy markers for the visited target only.",
     },
 )
 
@@ -477,6 +477,9 @@ _CLIPPY_OUTPUT_GROUPS = ["clippy_checks", "clippy_output"]
 def _rust_clippy_test_aspect_impl(target, ctx):
     return lint_test_aspect_impl(target, ctx, RustClippyTestInfo, _CLIPPY_OUTPUT_GROUPS)
 
+def _rust_clippy_test_impl(ctx):
+    return lint_test_rule_impl(ctx, RustClippyTestInfo, _CLIPPY_OUTPUT_GROUPS)
+
 _rust_clippy_test_aspect = aspect(
     implementation = _rust_clippy_test_aspect_impl,
     attr_aspects = ["deps", "proc_macro_deps", "crate"],
@@ -484,9 +487,6 @@ _rust_clippy_test_aspect = aspect(
     provides = [RustClippyTestInfo],
     doc = "Walks `deps`/`proc_macro_deps`/`crate` and rolls up the markers produced by `rust_clippy_aspect` into a transitive `RustClippyTestInfo`.",
 )
-
-def _rust_clippy_test_impl(ctx):
-    return lint_test_rule_impl(ctx, RustClippyTestInfo)
 
 rust_clippy_test = rule(
     implementation = _rust_clippy_test_impl,
@@ -505,14 +505,18 @@ rust_clippy_test = rule(
     doc = """\
 A test rule that runs `clippy` over a set of Rust targets.
 
-By default (`transitive = True`), the aspect walks `deps`, `proc_macro_deps`, and `crate`
-transitively so that listing a top-level target checks its whole crate graph. Set
-`transitive = False` to run clippy only on the exact targets listed.
+By default (`transitive = False`), only the exact targets listed are checked. Set
+`transitive = True` to walk `deps`, `proc_macro_deps`, and `crate` so that listing a
+top-level target checks its whole crate graph.
 
 The clippy actions run during the build phase, so a clippy failure fails `bazel test` before
-the test executable is invoked. When `capture_clippy_output` or `clippy_output_diagnostics` is
-set globally clippy exits 0 even on real issues; in that case the runner inspects the
-captured stderr / JSON diagnostics and reports the verdict.
+the test executable is invoked. The rule also exposes the collected markers under the
+`clippy_checks` output group, so `bazel build //x:my_clippy_test --output_groups=clippy_checks`
+drives the clippy actions without running the test.
+
+When `capture_clippy_output` or `clippy_output_diagnostics` is set globally clippy exits 0
+even on real issues; in that case the runner inspects the captured stderr / JSON diagnostics
+and reports the verdict.
 
 An optional `platform` attribute transitions `targets` to the given platform before running
 clippy.
@@ -522,11 +526,29 @@ Example:
 ```python
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy_test", "rust_library")
 
-rust_library(name = "lib", srcs = ["src/lib.rs"], edition = "2021")
-rust_binary(name = "app", srcs = ["src/main.rs"], edition = "2021", deps = [":lib"])
+rust_library(
+    name = "lib",
+    srcs = ["src/lib.rs"],
+    edition = "2021",
+)
 
-rust_clippy_test(name = "clippy_tree_test", targets = [":app"])
-rust_clippy_test(name = "clippy_app_only_test", targets = [":app"], transitive = False)
+rust_binary(
+    name = "app",
+    srcs = ["src/main.rs"],
+    edition = "2021",
+    deps = [":lib"],
+)
+
+rust_clippy_test(
+    name = "clippy_app_only_test",
+    targets = [":app"],
+)
+
+rust_clippy_test(
+    name = "clippy_tree_test",
+    targets = [":app"],
+    transitive = True,
+)
 ```
 
 Targets tagged `no_clippy`, `no_lint`, `nolint`, or `noclippy` are skipped.

--- a/rust/private/lint_test.bzl
+++ b/rust/private/lint_test.bzl
@@ -13,7 +13,15 @@ and the output-group names it collects).
 """
 
 def rlocationpath(file, workspace_name):
-    """Compute the runfile rlocationpath for a File."""
+    """Compute the runfile rlocationpath for a `File`.
+
+    Args:
+        file (File): The file to compute the rlocationpath for.
+        workspace_name (str): The name of the current workspace.
+
+    Returns:
+        str: The rlocationpath the runner should look up for `file`.
+    """
     if file.short_path.startswith("../"):
         return file.short_path[len("../"):]
     return "{}/{}".format(workspace_name, file.short_path)
@@ -39,8 +47,8 @@ LINT_TEST_COMMON_ATTRS = {
         doc = "Optional platform to transition `targets` to before running the aspect. When set, `--platforms` is switched to this label for the duration of this rule's aspect actions.",
     ),
     "transitive": attr.bool(
-        doc = "If True (default), lint `targets` and every crate reachable via `deps`, `proc_macro_deps`, and `crate`. If False, lint only the exact targets listed.",
-        default = True,
+        doc = "If True, lint `targets` and every crate reachable via `deps`, `proc_macro_deps`, and `crate`. If False, lint only the exact targets listed.",
+        default = False,
     ),
     "_allowlist_function_transition": attr.label(
         default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
@@ -57,17 +65,28 @@ def lint_test_aspect_impl(target, ctx, info_provider, output_group_names):
     """Thin collector: walk deps and roll up the markers the underlying aspect produced.
 
     Args:
-        target: Aspect target.
-        ctx: Aspect ctx.
-        info_provider: Provider type to read from deps and return.
-        output_group_names: List[str] of `OutputGroupInfo` field names to
-            collect from the current target (e.g. `["clippy_checks", "clippy_output"]`
-            or `["rustfmt_checks"]`).
+        target (Target): The target the aspect is running on.
+        ctx (ctx): The aspect's context object.
+        info_provider (provider): The provider type to read from deps and return
+            (e.g. `RustClippyTestInfo` or `RustfmtTestInfo`).
+        output_group_names (list): A `list` of `str` naming the `OutputGroupInfo`
+            fields to collect from the current target (e.g.
+            `["clippy_checks", "clippy_output"]` or `["rustfmt_checks"]`).
 
     Returns:
-        A single-element list with a `info_provider(direct_markers, checks)`.
+        list: A single-element list containing an `info_provider` with `direct`
+            (`depset[File]`) for `target` and `checks` (`depset[File]`) that
+            folds in every dep's `checks`.
     """
-    transitive = []
+    direct_depsets = []
+    if OutputGroupInfo in target:
+        og = target[OutputGroupInfo]
+        for name in output_group_names:
+            if hasattr(og, name):
+                direct_depsets.append(getattr(og, name))
+    direct = depset(transitive = direct_depsets)
+
+    transitive = [direct]
     for attr_name in ("deps", "proc_macro_deps"):
         for dep in getattr(ctx.rule.attr, attr_name, []):
             if info_provider in dep:
@@ -76,27 +95,26 @@ def lint_test_aspect_impl(target, ctx, info_provider, output_group_names):
     if crate_dep and info_provider in crate_dep:
         transitive.append(crate_dep[info_provider].checks)
 
-    direct = []
-    if OutputGroupInfo in target:
-        og = target[OutputGroupInfo]
-        for name in output_group_names:
-            if hasattr(og, name):
-                direct = direct + getattr(og, name).to_list()
-
     return [info_provider(
-        direct_markers = direct,
-        checks = depset(direct, transitive = transitive),
+        direct = direct,
+        checks = depset(transitive = transitive),
     )]
 
-def lint_test_rule_impl(ctx, info_provider):
+def lint_test_rule_impl(ctx, info_provider, output_group_names):
     """Symlink the shared runner and hand it the collected marker rlocationpaths.
 
     Args:
-        ctx: Rule ctx.
-        info_provider: Provider carrying `direct_markers` / `checks`.
+        ctx (ctx): The rule's context object.
+        info_provider (provider): The provider type produced by the rule's
+            aspect, carrying `direct` and `checks` depsets.
+        output_group_names (list): A `list` of `str` naming the
+            `OutputGroupInfo` fields to expose the collected markers under
+            (e.g. `["clippy_checks", "clippy_output"]` or
+            `["rustfmt_checks"]`). Each name maps to the same `checks` depset.
 
     Returns:
-        DefaultInfo + RunEnvironmentInfo for the test.
+        list: `[DefaultInfo, RunEnvironmentInfo, OutputGroupInfo]` for the
+            test target.
     """
     is_windows = ctx.executable._runner.extension == ".exe"
     runner = ctx.actions.declare_file("{}{}".format(
@@ -109,24 +127,21 @@ def lint_test_rule_impl(ctx, info_provider):
         is_executable = True,
     )
 
-    marker_files = []
     check_depsets = []
     for target in ctx.attr.targets:
         if info_provider not in target:
             continue
         info = target[info_provider]
-        if ctx.attr.transitive:
-            check_depsets.append(info.checks)
-        else:
-            marker_files.extend(info.direct_markers)
+        check_depsets.append(info.checks if ctx.attr.transitive else info.direct)
+    checks = depset(transitive = check_depsets)
 
-    checks = depset(marker_files, transitive = check_depsets)
     runfiles = ctx.runfiles(transitive_files = checks).merge(
         ctx.attr._runner[DefaultInfo].default_runfiles,
     )
 
+    workspace_name = ctx.workspace_name
     markers_env = ctx.configuration.host_path_separator.join([
-        rlocationpath(f, ctx.workspace_name)
+        rlocationpath(f, workspace_name)
         for f in checks.to_list()
     ])
 
@@ -140,4 +155,5 @@ def lint_test_rule_impl(ctx, info_provider):
             "RUST_BACKTRACE": "1",
             "RUST_LINT_TEST_MARKERS": markers_env,
         }),
+        OutputGroupInfo(**{name: checks for name in output_group_names}),
     ]

--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -195,7 +195,7 @@ RustfmtTestInfo = provider(
     doc = "Rustfmt check outputs collected by `rustfmt_test` from the underlying `rustfmt_aspect`.",
     fields = {
         "checks": "depset[File]: Rustfmt markers for the visited target plus every crate reached via `deps`, `proc_macro_deps`, and `crate`.",
-        "direct_markers": "list[File]: Rustfmt markers for the visited target only.",
+        "direct": "depset[File]: Rustfmt markers for the visited target only.",
     },
 )
 
@@ -204,6 +204,9 @@ _RUSTFMT_OUTPUT_GROUPS = ["rustfmt_checks"]
 def _rustfmt_test_aspect_impl(target, ctx):
     return lint_test_aspect_impl(target, ctx, RustfmtTestInfo, _RUSTFMT_OUTPUT_GROUPS)
 
+def _rustfmt_test_impl(ctx):
+    return lint_test_rule_impl(ctx, RustfmtTestInfo, _RUSTFMT_OUTPUT_GROUPS)
+
 _rustfmt_test_aspect = aspect(
     implementation = _rustfmt_test_aspect_impl,
     attr_aspects = ["deps", "proc_macro_deps", "crate"],
@@ -211,9 +214,6 @@ _rustfmt_test_aspect = aspect(
     provides = [RustfmtTestInfo],
     doc = "Walks `deps`/`proc_macro_deps`/`crate` and rolls up the markers produced by `rustfmt_aspect` into a transitive `RustfmtTestInfo`.",
 )
-
-def _rustfmt_test_impl(ctx):
-    return lint_test_rule_impl(ctx, RustfmtTestInfo)
 
 rustfmt_test = rule(
     implementation = _rustfmt_test_impl,
@@ -232,11 +232,14 @@ rustfmt_test = rule(
     doc = """\
 A test rule that runs `rustfmt --check` over a set of Rust targets.
 
-By default (`transitive = True`), the aspect walks `deps`, `proc_macro_deps`, and `crate`
-transitively so that listing a top-level target checks its whole crate graph. Set
-`transitive = False` to format only the exact targets listed. The `rustfmt` actions run
-during the build phase, so a formatting failure fails `bazel test` before the test
-executable is invoked.
+By default (`transitive = False`), only the exact targets listed are checked. Set
+`transitive = True` to walk `deps`, `proc_macro_deps`, and `crate` so that listing a
+top-level target checks its whole crate graph.
+
+The `rustfmt` actions run during the build phase, so a formatting failure fails `bazel test`
+before the test executable is invoked. The rule also exposes the collected markers under the
+`rustfmt_checks` output group, so `bazel build //x:my_fmt_test --output_groups=rustfmt_checks`
+drives the rustfmt actions without running the test.
 
 An optional `platform` attribute transitions `targets` to the given platform before running
 `rustfmt`.
@@ -246,11 +249,29 @@ Example:
 ```python
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rustfmt_test")
 
-rust_library(name = "lib", srcs = ["src/lib.rs"], edition = "2021")
-rust_binary(name = "app", srcs = ["src/main.rs"], edition = "2021", deps = [":lib"])
+rust_library(
+    name = "lib",
+    srcs = ["src/lib.rs"],
+    edition = "2021",
+)
 
-rustfmt_test(name = "fmt_tree_test", targets = [":app"])
-rustfmt_test(name = "fmt_app_only_test", targets = [":app"], transitive = False)
+rust_binary(
+    name = "app",
+    srcs = ["src/main.rs"],
+    edition = "2021",
+    deps = [":lib"],
+)
+
+rustfmt_test(
+    name = "fmt_app_only_test",
+    targets = [":app"]
+)
+
+rustfmt_test(
+    name = "fmt_tree_test",
+    targets = [":app"],
+    transitive = True,
+)
 ```
 
 Targets tagged `no_format`, `no_rustfmt`, or `norustfmt` are skipped.

--- a/test/lint_tree/BUILD.bazel
+++ b/test/lint_tree/BUILD.bazel
@@ -38,11 +38,13 @@ rust_binary(
 rust_clippy_test(
     name = "tree_clippy_test",
     targets = [":app"],
+    transitive = True,
 )
 
 rustfmt_test(
     name = "tree_fmt_test",
     targets = [":app"],
+    transitive = True,
 )
 
 # Leaf tagged `no_clippy`. The wrapper `deps` on it but does not `use` it —
@@ -69,6 +71,7 @@ rust_library(
 rust_clippy_test(
     name = "tree_clippy_test_with_skip",
     targets = [":wrapper_over_no_clippy"],
+    transitive = True,
 )
 
 # Leaf tagged `no_rustfmt`.
@@ -93,6 +96,7 @@ rust_library(
 rustfmt_test(
     name = "tree_fmt_test_with_skip",
     targets = [":wrapper_over_no_rustfmt"],
+    transitive = True,
 )
 
 # `transitive = False` variants: only the exact target listed is checked,

--- a/test/unit/lint_tests/lint_tests.bzl
+++ b/test/unit/lint_tests/lint_tests.bzl
@@ -1,6 +1,6 @@
 """Unit tests for `rust_clippy_test` and `rustfmt_test`.
 
-One test per rule. Each verifies that with `transitive = True` (the default)
+One test per rule. Each verifies that with `transitive = True`
 the collected marker count matches the dep graph, and that a crate tagged
 for opt-out is skipped without breaking propagation to its own deps.
 """
@@ -26,10 +26,11 @@ def _markers(target):
     raw = target[RunEnvironmentInfo].environment.get("RUST_LINT_TEST_MARKERS", "")
     return [s for s in raw.replace(";", ":").split(":") if s]
 
-def _make_transitive_count_test(marker_suffix):
+def _make_transitive_count_test(marker_suffix, output_group_name):
     def _impl(ctx):
         env = analysistest.begin(ctx)
-        markers = _markers(analysistest.target_under_test(env))
+        tut = analysistest.target_under_test(env)
+        markers = _markers(tut)
 
         bin_marker = "bin" + marker_suffix
         leaf_marker = "leaf" + marker_suffix
@@ -57,12 +58,23 @@ def _make_transitive_count_test(marker_suffix):
                 tagged_marker in m,
                 "Tagged crate should not have produced marker {}".format(m),
             )
+
+        # The output group is what `bazel build --output_groups=<name>`
+        # drives; without it, only the runner symlink is a default output
+        # and the lint aspect never fires under a `build` invocation.
+        og_files = getattr(tut[OutputGroupInfo], output_group_name).to_list()
+        asserts.equals(
+            env,
+            sorted([m.split("/")[-1] for m in markers]),
+            sorted([f.basename for f in og_files]),
+            "`{}` output group must match RUST_LINT_TEST_MARKERS".format(output_group_name),
+        )
         return analysistest.end(env)
 
     return analysistest.make(_impl)
 
-clippy_transitive_test = _make_transitive_count_test(".clippy.ok")
-rustfmt_transitive_test = _make_transitive_count_test(".rustfmt.ok")
+clippy_transitive_test = _make_transitive_count_test(".clippy.ok", "clippy_checks")
+rustfmt_transitive_test = _make_transitive_count_test(".rustfmt.ok", "rustfmt_checks")
 
 def lint_tests_suite(name):
     """Wire up the fixture graph and the two analysistests.
@@ -101,11 +113,13 @@ def lint_tests_suite(name):
         name = "clippy_fixture",
         targets = [":bin"],
         tags = ["manual"],
+        transitive = True,
     )
     rustfmt_test(
         name = "rustfmt_fixture",
         targets = [":bin"],
         tags = ["manual"],
+        transitive = True,
     )
 
     clippy_transitive_test(


### PR DESCRIPTION
This change updates `rustfmt_test` and `rust_clippy_test` to behave more consistently with the aspect output groups by ensuring transitive targets in the transitioned configuration get added to `//...` invocations.