### PR TITLE
Fix NoneType error in rustdoc

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -951,8 +951,7 @@ def construct_arguments(
         skip_expanding_rustc_env = False,
         require_explicit_unstable_features = False,
         error_format = None,
-        allowed_unstable_rust_features = None,
-        emit_out_dir_flag = True):
+        allowed_unstable_rust_features = None):
     """Builds an Args object containing common rustc flags
 
     Args:
@@ -1024,10 +1023,6 @@ def construct_arguments(
         require_explicit_unstable_features (bool): Whether to require all unstable features to be explicitly opted in to using `-Zallow-features=...`.
         error_format (str, optional): Error format to pass to the `--error-format` command line argument. If set to None, uses the "_error_format" entry in `attr`.
         allowed_unstable_rust_features (list, optional): List of unstable Rust language features allowed for this target.
-        emit_out_dir_flag (bool): Whether to emit `--out-dir=<crate_info.output.dirname>`.
-            Defaults to True (the rustc case). Set to False for rustdoc actions that
-            emit `--output` themselves — rustdoc rejects `--out-dir` and `--output`
-            together with `error: cannot use both 'out-dir' and 'output' at once`.
 
     Returns:
         tuple: A tuple of the following items
@@ -1213,15 +1208,21 @@ def construct_arguments(
         rustc_flags.add(output_hash, format = "--codegen=metadata=-%s")
         rustc_flags.add(output_hash, format = "--codegen=extra-filename=-%s")
 
-    if output_dir and emit_out_dir_flag:
-        # Use add_all with the output File and a map_each callback that returns the
-        # dirname so Bazel can apply path mapping (--experimental_output_paths=strip)
-        # to the directory portion of the path. `expand_directories = False`
-        # because rustdoc's `output` is a declared directory (the HTML tree);
-        # we want its dirname, not its contents.
+    if output_dir:
+        # Emit `--out-dir=<place-to-put-outputs>`. Semantics depend on whether
+        # `crate_info.output` is a file (rustc: rlib/binary) or a directory
+        # (rustdoc: HTML tree):
+        #   - File output -> the containing directory (`.dirname`); rustc writes
+        #     the file there.
+        #   - Directory output -> the directory path itself (`.path`); rustdoc
+        #     writes its HTML tree into it.
+        # Routing through `add_all([crate_info.output], map_each=...)` lets Bazel
+        # path mapping (`--experimental_output_paths=strip`) rewrite the value
+        # at execution time. `expand_directories = False` so directory-typed
+        # outputs pass through as a single argv entry.
         rustc_flags.add_all(
             [crate_info.output],
-            map_each = _get_dirname,
+            map_each = _get_out_dir_path,
             format_each = "--out-dir=%s",
             expand_directories = False,
         )
@@ -2887,6 +2888,21 @@ def _add_native_link_flags(
                     map_each = get_lib_name,
                     format_each = "-lstatic=%s",
                 )
+
+def _get_out_dir_path(file):
+    """Return the path suitable for `--out-dir=<value>`.
+
+    For a file output (rlib/binary), the containing directory. For a directory
+    output (rustdoc HTML tree), the directory itself — rustdoc writes into
+    `<--out-dir>/<crate_name>/`, and we want that inside the declared directory.
+
+    Args:
+        file (File): The crate's output File.
+
+    Returns:
+        str: Directory path to hand to `--out-dir=`.
+    """
+    return file.path if file.is_directory else file.dirname
 
 def _get_crate_root_path(args):
     file, root_path = args

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -951,7 +951,8 @@ def construct_arguments(
         skip_expanding_rustc_env = False,
         require_explicit_unstable_features = False,
         error_format = None,
-        allowed_unstable_rust_features = None):
+        allowed_unstable_rust_features = None,
+        emit_out_dir_flag = True):
     """Builds an Args object containing common rustc flags
 
     Args:
@@ -1023,6 +1024,10 @@ def construct_arguments(
         require_explicit_unstable_features (bool): Whether to require all unstable features to be explicitly opted in to using `-Zallow-features=...`.
         error_format (str, optional): Error format to pass to the `--error-format` command line argument. If set to None, uses the "_error_format" entry in `attr`.
         allowed_unstable_rust_features (list, optional): List of unstable Rust language features allowed for this target.
+        emit_out_dir_flag (bool): Whether to emit `--out-dir=<crate_info.output.dirname>`.
+            Defaults to True (the rustc case). Set to False for rustdoc actions that
+            emit `--output` themselves — rustdoc rejects `--out-dir` and `--output`
+            together with `error: cannot use both 'out-dir' and 'output' at once`.
 
     Returns:
         tuple: A tuple of the following items
@@ -1037,7 +1042,7 @@ def construct_arguments(
     if build_metadata and not use_json_output:
         fail("build_metadata requires parse_json_output")
 
-    output_dir = getattr(crate_info.output, "dirname", None)
+    output_dir = crate_info.output.dirname
     linker_script = getattr(file, "linker_script", None)
 
     env = _get_rustc_env(attr, toolchain, crate_info.name)
@@ -1088,11 +1093,15 @@ def construct_arguments(
         # output tree whenever the crate has a generated input. Keep the manifest
         # directory next to those transformed inputs so proc macros can find them.
         # Derive the directory from a File so Bazel can apply path mapping.
+        # `expand_directories = False` because rustdoc's `crate_info.output` is
+        # a declared directory (the HTML tree) — we want its dirname, not its
+        # contents.
         process_wrapper_flags.add_all(
             [crate_info.output],
             before_each = "--subst",
             format_each = "cargo_manifest_dir=%s",
             map_each = _get_dirname,
+            expand_directories = False,
         )
         env["CARGO_MANIFEST_DIR"] = "${pwd}/${cargo_manifest_dir}"
 
@@ -1204,11 +1213,18 @@ def construct_arguments(
         rustc_flags.add(output_hash, format = "--codegen=metadata=-%s")
         rustc_flags.add(output_hash, format = "--codegen=extra-filename=-%s")
 
-    if output_dir:
+    if output_dir and emit_out_dir_flag:
         # Use add_all with the output File and a map_each callback that returns the
         # dirname so Bazel can apply path mapping (--experimental_output_paths=strip)
-        # to the directory portion of the path.
-        rustc_flags.add_all([crate_info.output], map_each = _get_dirname, format_each = "--out-dir=%s")
+        # to the directory portion of the path. `expand_directories = False`
+        # because rustdoc's `output` is a declared directory (the HTML tree);
+        # we want its dirname, not its contents.
+        rustc_flags.add_all(
+            [crate_info.output],
+            map_each = _get_dirname,
+            format_each = "--out-dir=%s",
+            expand_directories = False,
+        )
 
     compilation_mode = get_compilation_mode_opts(ctx, toolchain)
     rustc_flags.add(compilation_mode.opt_level, format = "--codegen=opt-level=%s")
@@ -1227,7 +1243,7 @@ def construct_arguments(
 
     emit_without_paths = []
     for kind in emit:
-        if kind == "link" and crate_info.type == "bin" and crate_info.output != None:
+        if kind == "link" and crate_info.type == "bin":
             rustc_flags.add(crate_info.output, format = "--emit=link=%s")
         elif type(kind) in ["tuple", "list"] and len(kind) == 2:
             # 'kind' is a (string, File) tuple/list. Passing the File object directly to

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -28,14 +28,25 @@ load(
     "get_preferred_artifact",
 )
 
-def _strip_crate_info_output(crate_info):
-    """Set the CrateInfo.output to None for a given CrateInfo provider.
+def _rustdoc_crate_info(crate_info, output):
+    """Clone a `CrateInfo` provider for use by a rustdoc action.
+
+    The `CrateInfo` provider documents `output` as a required `File`
+    ([rust/private/providers.bzl](../providers.bzl)) and every other
+    consumer of `crate_info.output` in the tree assumes it. rustdoc
+    actions don't produce the crate's compile output (`.rlib`/binary),
+    so we swap in a rustdoc-owned `File` — the rustdoc HTML directory
+    when the caller has one, or the crate's root source file as a
+    valid fallback for actions (like the legacy test-writer path) that
+    have no rustdoc-produced `File` at analysis time.
 
     Args:
-        crate_info (CrateInfo): A provider
+        crate_info (CrateInfo): The original provider.
+        output (File): A `File` to publish as the rustdoc `CrateInfo`'s
+            `output`. Must be non-`None`.
 
     Returns:
-        CrateInfo: A modified CrateInfo provider
+        CrateInfo: A modified CrateInfo provider.
     """
     return rust_common.create_crate_info(
         name = crate_info.name,
@@ -46,8 +57,7 @@ def _strip_crate_info_output(crate_info):
         deps = crate_info.deps,
         proc_macro_deps = crate_info.proc_macro_deps,
         aliases = crate_info.aliases,
-        # This crate info should have no output
-        output = None,
+        output = output,
         metadata = None,
         edition = crate_info.edition,
         rustc_env = crate_info.rustc_env,
@@ -136,11 +146,11 @@ def rustdoc_compile_action(
         include_link_flags = False,
     )
 
-    # Since this crate is not actually producing the output described by the
-    # given CrateInfo, this attribute needs to be stripped to allow the rest
-    # of the rustc functionality in `construct_arguments` to avoid generating
-    # arguments expecting to do so.
-    rustdoc_crate_info = _strip_crate_info_output(crate_info)
+    # rustdoc actions don't produce the crate's compile output, so we swap in
+    # a rustdoc-owned `File` for the `CrateInfo` handed to `construct_arguments`.
+    # Prefer the caller-supplied rustdoc output when available; otherwise fall
+    # back to the crate root, which is always a `File` per the provider contract.
+    rustdoc_crate_info = _rustdoc_crate_info(crate_info, output if output != None else crate_info.root)
 
     # rustdoc does not understand linker flags like -lstatic that
     # `include_link_flags` generates. So we manually build flags that only apply
@@ -191,6 +201,9 @@ def rustdoc_compile_action(
         include_link_flags = False,
         force_depend_on_objects = force_depend_on_objects,
         skip_expanding_rustc_env = True,
+        # rustdoc rejects `--out-dir` and `--output` together; when the caller
+        # supplies an `output`, we already pass `--output <output>` above.
+        emit_out_dir_flag = output == None,
     )
 
     # Because rustdoc tests compile tests outside of the sandbox, the sysroot

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -96,14 +96,6 @@ def rustdoc_compile_action(
     if force_depend_on_objects == None:
         force_depend_on_objects = is_test
 
-    # If an output was provided, ensure it's used in rustdoc arguments
-    if output:
-        rustdoc_flags.add_all(
-            [output],
-            before_each = "--output",
-            expand_directories = False,
-        )
-
     # Specify rustc flags for lints, if they were provided.
     lint_files = []
     if lints_info:
@@ -201,9 +193,6 @@ def rustdoc_compile_action(
         include_link_flags = False,
         force_depend_on_objects = force_depend_on_objects,
         skip_expanding_rustc_env = True,
-        # rustdoc rejects `--out-dir` and `--output` together; when the caller
-        # supplies an `output`, we already pass `--output <output>` above.
-        emit_out_dir_flag = output == None,
     )
 
     # Because rustdoc tests compile tests outside of the sandbox, the sysroot

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -1,6 +1,7 @@
 """Unittest to verify properties of rustdoc rules"""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//cargo:defs.bzl", "cargo_build_script")
 load(
@@ -222,11 +223,51 @@ def _target_maker(rule_fn, name, rustdoc_deps = [], rustdoc_proc_macro_deps = []
         target_compatible_with = NOT_WINDOWS,
     )
 
+def _rustdoc_for_generated_root_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+
+    _common_rustdoc_checks(env, tut)
+
+    return analysistest.end(env)
+
+rustdoc_for_generated_root_test = analysistest.make(_rustdoc_for_generated_root_test_impl)
+
 def _define_targets():
     rust_library(
         name = "adder",
         srcs = ["adder.rs"],
         edition = "2018",
+    )
+
+    write_file(
+        name = "gen_lib_src",
+        out = "gen_lib.rs",
+        content = [
+            "/// One.",
+            "/// ```",
+            "/// assert_eq!(1, 1);",
+            "/// ```",
+            "pub fn one() -> u32 { 1 }",
+            "",
+        ],
+    )
+
+    rust_library(
+        name = "gen_lib",
+        srcs = [":gen_lib.rs"],
+        edition = "2021",
+    )
+
+    rust_doc(
+        name = "gen_lib_doc",
+        crate = ":gen_lib",
+    )
+
+    rust_doc_test(
+        name = "gen_lib_doc_test",
+        crate = ":gen_lib",
+        target_compatible_with = NOT_WINDOWS,
     )
 
     _target_maker(
@@ -492,6 +533,11 @@ def rustdoc_test_suite(name):
         target_under_test = ":lib_with_cc_library_doctest",
     )
 
+    rustdoc_for_generated_root_test(
+        name = "rustdoc_for_generated_root_test",
+        target_under_test = ":gen_lib_doc",
+    )
+
     native.filegroup(
         name = "lib_doc_zip",
         srcs = [":lib_doc.zip"],
@@ -516,6 +562,7 @@ def rustdoc_test_suite(name):
             ":rustdoc_with_args_test",
             ":rustdoc_with_json_error_format_test",
             ":rustdoc_test_uses_cc_library_native_lib_test",
+            ":rustdoc_for_generated_root_test",
             ":rustdoc_zip_output_test",
         ],
     )


### PR DESCRIPTION
There seemed to be a confusion around `CrateInfo.output` being optional within the rustdoc rules that leads to a `NoneType` error when using rustdoc on a generated crate root:
```
external/rules_rust+/rust/private/rustc.bzl:1090:38: Traceback (most recent call last):
File "external/rules_rust+/rust/private/rustc.bzl", line 2883, column 16, in _get_dirname
    return file.dirname
Error: 'NoneType' value has no field or method 'dirname'
```

This change adds a proper output to satisfy the the current `CrateInfo` interface.