### PR TITLE
Add build_script_env_files crate annotation

### DIFF
--- a/cargo/private/cargo_build_script_runner/bin.rs
+++ b/cargo/private/cargo_build_script_runner/bin.rs
@@ -24,6 +24,44 @@ use std::process::Command;
 use cargo_build_script_runner::cargo_manifest_dir::{remove_symlink, symlink, RunfilesMaker};
 use cargo_build_script_runner::{BuildScriptOutput, CompileAndLinkFlags, SUPPRESS_WARNINGS_ENV};
 
+fn parse_env_file(contents: &str) -> Result<Vec<(String, String)>, String> {
+    fn push_variable(
+        variables: &mut Vec<(String, String)>,
+        variable: &mut String,
+    ) -> Result<(), String> {
+        let (key, value) = variable
+            .split_once('=')
+            .ok_or_else(|| "error: Wrong environment file format, should not happen".to_owned())?;
+        variables.push((key.to_owned(), value.to_owned()));
+        variable.clear();
+        Ok(())
+    }
+
+    let mut variables = Vec::new();
+    let mut variable = String::new();
+
+    for line in contents.lines() {
+        if let Some(value) = line.strip_suffix('\\') {
+            variable.push_str(value);
+            variable.push('\n');
+            continue;
+        }
+
+        variable.push_str(line);
+        if !variable.is_empty() {
+            push_variable(&mut variables, &mut variable)?;
+        }
+    }
+
+    // `str::lines` does not yield a final empty line, so finalize a value
+    // whose last line ended in a continuation as well.
+    if !variable.is_empty() {
+        push_variable(&mut variables, &mut variable)?;
+    }
+
+    Ok(variables)
+}
+
 fn run_buildrs() -> Result<(), String> {
     // We use exec_root.join rather than std::fs::canonicalize, to avoid resolving symlinks, as
     // some execution strategies and remote execution environments may use symlinks in ways which
@@ -107,25 +145,10 @@ fn run_buildrs() -> Result<(), String> {
     set_script_runfiles_env(&script_path, &mut command);
 
     for dep_env_path in input_dep_env_paths.iter() {
-        if let Ok(contents) = read_to_string(dep_env_path) {
-            for line in contents.split('\n') {
-                // split on empty contents will still produce a single empty string in iterable.
-                if line.is_empty() {
-                    continue;
-                }
-                match line.split_once('=') {
-                    Some((key, value)) => {
-                        command.env(key, value.replace("${pwd}", &exec_root.to_string_lossy()));
-                    }
-                    _ => {
-                        return Err(
-                            "error: Wrong environment file format, should not happen".to_owned()
-                        )
-                    }
-                }
-            }
-        } else {
-            return Err("error: Dependency environment file unreadable".to_owned());
+        let contents = read_to_string(dep_env_path)
+            .map_err(|_| "error: Dependency environment file unreadable".to_owned())?;
+        for (key, value) in parse_env_file(&contents)? {
+            command.env(key, value.replace("${pwd}", &exec_root.to_string_lossy()));
         }
     }
 

--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -1418,6 +1418,9 @@ _ANNOTATION_SELECT_ATTRS = {
     "build_script_env": attr.string_dict(
         doc = "Additional environment variables to set on a crate's `cargo_build_script::env` attribute.",
     ),
+    "build_script_env_files": _relative_label_list(
+        doc = "A list of labels to set on a crate's `cargo_build_script::build_script_env_files` attribute.",
+    ),
     "build_script_exec_properties": attr.string_dict(
         doc = "Execution properties to set on a crate's `cargo_build_script::exec_properties` attribute.",
     ),

--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -96,6 +96,7 @@ def _annotation(
         build_script_data_glob = None,
         build_script_deps = None,
         build_script_env = None,
+        build_script_env_files = None,
         build_script_exec_properties = None,
         build_script_link_deps = None,
         build_script_proc_macro_deps = None,
@@ -143,6 +144,8 @@ def _annotation(
             attribute.
         build_script_deps (list, optional): A list of labels to add to a crate's `cargo_build_script::deps` attribute.
         build_script_env (dict, optional): Additional environment variables to set when running the crate's `cargo_build_script` - sets that target's `build_script_env` attribute.
+        build_script_env_files (list, optional): A list of labels to set on a crate's
+            `cargo_build_script::build_script_env_files` attribute.
         build_script_exec_properties (dict, optional): Execution properties to set on a crate's `cargo_build_script::exec_properties` attribute.
         build_script_link_deps:  A list of labels to add to a crate's `cargo_build_script::link_deps` attribute.
         build_script_proc_macro_deps (list, optional): A list of labels to add to a crate's
@@ -214,6 +217,7 @@ def _annotation(
             build_script_data_glob = build_script_data_glob,
             build_script_deps = _stringify_list(build_script_deps),
             build_script_env = build_script_env,
+            build_script_env_files = _stringify_list(build_script_env_files),
             build_script_exec_properties = build_script_exec_properties,
             build_script_link_deps = build_script_link_deps,
             build_script_proc_macro_deps = _stringify_list(build_script_proc_macro_deps),

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -357,6 +357,10 @@ pub(crate) struct CrateAnnotations {
     /// [build_script_env](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-rustc_env) attribute.
     pub(crate) build_script_env: Option<Select<BTreeMap<String, String>>>,
 
+    /// Additional environment variable files to pass to a build script's
+    /// [build_script_env_files](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-build_script_env_files) attribute.
+    pub(crate) build_script_env_files: Option<Select<BTreeSet<String>>>,
+
     /// Additional rustc_env flags to pass to a build script's
     /// [rustc_env](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-rustc_env) attribute.
     pub(crate) build_script_rustc_env: Option<Select<BTreeMap<String, String>>>,
@@ -473,6 +477,7 @@ impl Add for CrateAnnotations {
             build_script_tools: select_merge(self.build_script_tools, rhs.build_script_tools),
             build_script_data_glob: joined_extra_member!(self.build_script_data_glob, rhs.build_script_data_glob, BTreeSet::new, BTreeSet::extend),
             build_script_env: select_merge(self.build_script_env, rhs.build_script_env),
+            build_script_env_files: select_merge(self.build_script_env_files, rhs.build_script_env_files),
             build_script_rustc_env: select_merge(self.build_script_rustc_env, rhs.build_script_rustc_env),
             build_script_exec_properties: select_merge(self.build_script_exec_properties, rhs.build_script_exec_properties),
             build_script_toolchains: joined_extra_member!(self.build_script_toolchains, rhs.build_script_toolchains, BTreeSet::new, BTreeSet::extend),

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -710,6 +710,12 @@ impl CrateContext {
                         Select::merge(attrs.build_script_env.clone(), extra.clone());
                 }
 
+                // Build script env files
+                if let Some(extra) = &crate_extra.build_script_env_files {
+                    attrs.build_script_env_files =
+                        Select::merge(attrs.build_script_env_files.clone(), extra.clone());
+                }
+
                 // Exec properties
                 if let Some(extra) = &crate_extra.build_script_exec_properties {
                     attrs.exec_properties =
@@ -1099,6 +1105,59 @@ mod test {
 
         // Cargo build scripts should include all sources
         assert!(context.build_script_attrs.unwrap().data_glob.contains("**"));
+    }
+
+    #[test]
+    fn context_with_build_script_env_files_annotation() {
+        let mut build_script_env_files =
+            Select::from_value(BTreeSet::from(["@//:build-script.env".to_owned()]));
+        build_script_env_files.insert(
+            "@//:linux-build-script.env".to_owned(),
+            Some("x86_64-unknown-linux-gnu".to_owned()),
+        );
+
+        let mut config = crate::config::Config::default();
+        config.annotations.insert(
+            crate::config::CrateNameAndVersionReq::new(
+                "openssl-sys".to_owned(),
+                "0.9.87".parse().unwrap(),
+            ),
+            CrateAnnotations {
+                build_script_env_files: Some(build_script_env_files.clone()),
+                ..CrateAnnotations::default()
+            },
+        );
+
+        let annotations = Annotations::new(
+            crate::test::metadata::build_scripts(),
+            &None,
+            crate::test::lockfile::build_scripts(),
+            config,
+            Utf8Path::new("/tmp/bazelworkspace"),
+        )
+        .unwrap();
+        let package_id = PackageId {
+            repr: "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
+                .to_owned(),
+        };
+        let crate_annotation = &annotations.metadata.crates[&package_id];
+
+        let context = CrateContext::new(
+            crate_annotation,
+            &annotations.metadata.packages,
+            &annotations.lockfile.crates,
+            &annotations.pairred_extras,
+            &annotations.metadata.workspace_metadata.tree_metadata,
+            false,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            context.build_script_attrs.unwrap().build_script_env_files,
+            build_script_env_files
+        );
     }
 
     #[test]

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -305,7 +305,7 @@ mod test {
         );
 
         assert_eq!(
-            Digest("c92abd7d08fb65f955500488beb775486f537d4ec30a5a2f1ea6dbeead3eace0".to_owned()),
+            Digest("4e15466c65fbe0069462f551062a2e71fcc1b7a2f614c5df14eed322aa6f90a4".to_owned()),
             digest,
         );
     }

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -691,6 +691,12 @@ impl Renderer {
                     .unwrap_or_default(),
                 platforms,
             ),
+            build_script_env_files: SelectSet::new(
+                attrs
+                    .map(|attrs| attrs.build_script_env_files.clone())
+                    .unwrap_or_default(),
+                platforms,
+            ),
             use_default_shell_env: attrs.and_then(|a| a.use_default_shell_env),
             use_cc_toolchain: attrs.and_then(|a| a.use_cc_toolchain),
             compile_data: make_data_with_exclude(
@@ -1387,6 +1393,9 @@ mod test {
         let attrs = BuildScriptAttributes {
             use_default_shell_env: Some(1),
             use_cc_toolchain: Some(0),
+            build_script_env_files: Select::from_value(BTreeSet::from([
+                "//:build_script.env".to_owned()
+            ])),
             exec_properties: Select::from_value(BTreeMap::from([
                 ("OSFamily".to_owned(), "Linux".to_owned()),
                 ("container-image".to_owned(), "docker://my-image".to_owned()),
@@ -1470,6 +1479,16 @@ mod test {
         );
         assert!(
             build_file_content.contains("\"container-image\": \"docker://my-image\""),
+            "```\n{}```\n",
+            build_file_content
+        );
+        assert!(
+            build_file_content.contains("build_script_env_files = ["),
+            "```\n{}```\n",
+            build_file_content
+        );
+        assert!(
+            build_file_content.contains("\"//:build_script.env\""),
             "```\n{}```\n",
             build_file_content
         );

--- a/crate_universe/src/utils/starlark.rs
+++ b/crate_universe/src/utils/starlark.rs
@@ -98,6 +98,8 @@ pub(crate) struct CargoBuildScript {
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) build_script_env: SelectDict<String, String>,
+    #[serde(skip_serializing_if = "SelectSet::is_empty")]
+    pub(crate) build_script_env_files: SelectSet<String>,
     #[serde(skip_serializing_if = "Data::is_empty")]
     pub(crate) compile_data: Data,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7fdbd86a97bee065cf950f2f32e3ef7b4be29aa190dbef98fdfeb5ea7248463a",
+  "checksum": "fb5ba9be8b4537eaec17b6d71cf44b7307203b2d5712bbd663bef22df1945e20",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c54d4f51cc5814b68c9f857661b5026e76faadc13031a15813001c1355f33740",
+  "checksum": "f78faae1578a3a1abf5c2a279bb1f19acde30a74ce0b3dd66b7e4aa51e0f19c2",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f66173a33ce991a40c6a7c182da213ac37422d118e77219360862c29cc2ab32f",
+  "checksum": "f4a39d9f7e8717f9bed88f3ff5ecc85e5c917311760356eb81fc09b7681a6b88",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3f40c89394886be831e875a5b4e25981987d6693dc7f9ecfb2c9c15cab0b6a4c",
+  "checksum": "d2be219e9bbbe6d7892735328b8a9f8463f09a90648492d3fbcc622b56ec8437",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fabb535deea69aa1e2c2c60b813f4f178da505f2d24366bf5319aecfce7ddd25",
+  "checksum": "88ad3a2b207d5f7af0c36de480098b39f90d40456fdc7f24f1001fc3067d9203",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "32a90b4e0ef6ffe0bcc2b958303ee046f8f06bf4536cc6025f99cd4be5c2078d",
+  "checksum": "c4db88b2f7719983402c4fe94a7206efa59d6f5374e05d00bfd6424046c88f5a",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "dd9bfb811c598d5901d147ef3c6d7f443a87e06aac24a4357be7b7f7f903c549",
+  "checksum": "ba8f220fc6a4b0065b91698b19960ba606ce9a9ee6ef2b7e53688f27f97ac673",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/cargo_aliases/cargo-bazel-lock.json
+++ b/crate_universe/tests/integration/cargo_aliases/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cff793caa5b5668e58c7363572ccee79f5ce31ca1618189f9a5ac962ecffa086",
+  "checksum": "74a8ac34e576c3cbccaa73f8e3005720a63fbdec3a8d0afa013f15d8030adbb7",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",

--- a/crate_universe/tests/integration/complicated_dependencies/cargo-bazel-lock.json
+++ b/crate_universe/tests/integration/complicated_dependencies/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "40f4490aa270d083c2bc0f33378209e17bd6ee61022986bf85d251cfd45411d4",
+  "checksum": "617db520c548604d90b01ed4d68bf9f200796f0faa2ffd65b832fc44be1f89a3",
   "crates": {
     "bitflags 2.11.1": {
       "name": "bitflags",

--- a/crate_universe/tests/integration/multi_package/cargo-bazel-lock.json
+++ b/crate_universe/tests/integration/multi_package/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ebc9b5249c82be34e4f6235ef604f17d3f06104ad121412942a7fb4a98ae74c4",
+  "checksum": "76a2c746f6daafbd3ebba2040da24951aaf5ab4e190febded5255f1e794924c4",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",

--- a/crate_universe/tests/integration/override_target/cargo-bazel-lock.json
+++ b/crate_universe/tests/integration/override_target/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "99a2231fa71bb4adfb11e88a006bd7541a899cf5f6c5afd4bf382fbb0941a582",
+  "checksum": "e934bc5d79ae609ba424d056b1999d7872ea9b000f0c7b11ad9f4d42db3a828f",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/cross_compile_nix/bazel/cargo/cargo-bazel-lock.json
+++ b/examples/cross_compile_nix/bazel/cargo/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "208f3d0ade5b4c82a84ad40e944b0a909fc1401598cb4c9da146a54d423761f2",
+  "checksum": "302831a3a50a99cbd5a34280eafe94d207642a9d55a1f3a232c6e3e71f09405d",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",


### PR DESCRIPTION
## Summary

Add `build_script_env_files` support to `crate.annotation`, allowing environment files to be passed to generated `cargo_build_script` targets.

The change:

- Exposes `build_script_env_files` through bzlmod and legacy crate annotations.
- Propagates the annotation through crate-universe configuration and build-script context.
- Renders the attribute on generated `cargo_build_script` rules.
- Supports unconditional and platform-selected values.
- Updates the configuration digest.
- Adds tests for annotation propagation and BUILD-file rendering.

## Testing

- `bazel test //crate_universe:unit_test`