### PR TITLE
Propagate wasm runfiles

### DIFF
--- a/extensions/wasm_bindgen/private/wasm_bindgen.bzl
+++ b/extensions/wasm_bindgen/private/wasm_bindgen.bzl
@@ -116,12 +116,15 @@ def _rust_wasm_bindgen_impl(ctx):
         flags = ctx.attr.bindgen_flags,
     )
 
+    wasm_target = ctx.attr.wasm_file[0]
+
     providers = [
         DefaultInfo(
             files = depset(
                 [info.wasm, info.snippets],
                 transitive = [info.js, info.ts],
             ),
+            runfiles = wasm_target[DefaultInfo].default_runfiles,
         ),
         info,
     ]

--- a/extensions/wasm_bindgen/test/runfiles/BUILD.bazel
+++ b/extensions/wasm_bindgen/test/runfiles/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":runfiles_test.bzl", "runfiles_test_suite")
+
+runfiles_test_suite(name = "runfiles_test_suite")

--- a/extensions/wasm_bindgen/test/runfiles/runfile_data.txt
+++ b/extensions/wasm_bindgen/test/runfiles/runfile_data.txt
@@ -1,0 +1,1 @@
+wasm_bindgen runfile propagation fixture

--- a/extensions/wasm_bindgen/test/runfiles/runfiles_test.bzl
+++ b/extensions/wasm_bindgen/test/runfiles/runfiles_test.bzl
@@ -1,0 +1,86 @@
+"""Unittests for `rust_wasm_bindgen` runfiles propagation."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_shared_library")
+load("//:defs.bzl", "rust_wasm_bindgen")
+
+def _is_in_runfiles(name, runfiles):
+    for file in runfiles:
+        if file.basename == name:
+            return True
+    return False
+
+def _runfiles_propagated_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+    runfiles = tut[DefaultInfo].default_runfiles.files.to_list()
+
+    asserts.true(
+        env,
+        _is_in_runfiles("runfile_data.txt", runfiles),
+        "Expected `runfile_data.txt` in the default runfiles of `{}`. Got: {}".format(
+            tut.label,
+            [f.short_path for f in runfiles],
+        ),
+    )
+
+    return analysistest.end(env)
+
+runfiles_propagated_test = analysistest.make(_runfiles_propagated_test_impl)
+
+def runfiles_test_suite(name):
+    """Entry-point macro called from the BUILD file.
+
+    Args:
+        name: Name of the macro.
+    """
+    rust_binary(
+        name = "runfiles_bin_wasm",
+        srcs = ["//test:main.rs"],
+        data = ["runfile_data.txt"],
+        edition = "2018",
+        target_compatible_with = ["@platforms//cpu:wasm32"],
+        deps = [
+            "@rules_rust_wasm_bindgen//3rdparty:wasm_bindgen",
+        ],
+    )
+
+    rust_shared_library(
+        name = "runfiles_lib_wasm",
+        srcs = ["//test:main.rs"],
+        data = ["runfile_data.txt"],
+        edition = "2018",
+        target_compatible_with = ["@platforms//cpu:wasm32"],
+        deps = [
+            "@rules_rust_wasm_bindgen//3rdparty:wasm_bindgen",
+        ],
+    )
+
+    rust_wasm_bindgen(
+        name = "runfiles_bin_bindgen",
+        wasm_file = ":runfiles_bin_wasm",
+    )
+
+    rust_wasm_bindgen(
+        name = "runfiles_lib_bindgen",
+        target = "web",
+        wasm_file = ":runfiles_lib_wasm",
+    )
+
+    runfiles_propagated_test(
+        name = "runfiles_bin_propagation_test",
+        target_under_test = ":runfiles_bin_bindgen",
+    )
+
+    runfiles_propagated_test(
+        name = "runfiles_lib_propagation_test",
+        target_under_test = ":runfiles_lib_bindgen",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":runfiles_bin_propagation_test",
+            ":runfiles_lib_propagation_test",
+        ],
+    )


### PR DESCRIPTION
This change allows the wasm targets to propagate runfiles with the bindgen outputs.