### PR TITLE
Add `RunfilesBuilder` to runfiles

### DIFF
--- a/rust/runfiles/Cargo.toml
+++ b/rust/runfiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runfiles"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 keywords = ["bazel"]
 license = "Apache-2.0"

--- a/rust/runfiles/runfiles.rs
+++ b/rust/runfiles/runfiles.rs
@@ -31,7 +31,9 @@
 //! ```
 
 use std::collections::{BTreeMap, HashMap};
+#[cfg(not(target_family = "wasm"))]
 use std::env;
+#[cfg(not(target_family = "wasm"))]
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -196,97 +198,21 @@ pub struct Runfiles {
 }
 
 impl Runfiles {
-    /// Creates a manifest based Runfiles object when RUNFILES_MANIFEST_FILE
-    /// environment variable is present, with an non-empty value, or a directory
-    /// based Runfiles object otherwise.
-    pub fn create() -> Result<Self> {
-        let mode = if let Some(manifest_file) =
-            std::env::var_os(MANIFEST_FILE_ENV_VAR).filter(|v| !v.is_empty())
-        {
-            Self::create_manifest_based(Path::new(&manifest_file))?
-        } else {
-            // Bazel itself does not publish a normative spec for how a
-            // runfiles library resolves runfiles when none of the
-            // documented env vars (`RUNFILES_MANIFEST_FILE`,
-            // `RUNFILES_DIR`, `TEST_SRCDIR`) are set — see
-            // <https://bazel.build/concepts/runfiles> and
-            // <https://bazel.build/reference/test-encyclopedia>, which
-            // describe the env vars and the runfiles tree but leave
-            // discovery to each language's library. What Bazel *does*
-            // guarantee on the producer side is that every binary
-            // action writes a `<binary>.runfiles_manifest` text file
-            // next to the output, and that `bazel run` / `bazel test`
-            // additionally materialize a `<binary>.runfiles/` directory.
-            //
-            // This block consolidates that producer behavior into a
-            // resolution order:
-            //   1. Whatever `find_runfiles_dir()` returns (env vars,
-            //      `<argv0>.runfiles/` sibling walk, or the `.runfiles`
-            //      ancestor walk). If it returns a directory containing
-            //      a `MANIFEST`, prefer that; otherwise use the dir.
-            //   2. Fall back to `<argv0>.runfiles_manifest` — the file
-            //      Bazel writes on every build action, even when no
-            //      `bazel run` invocation materialized the directory.
-            //      This is what lets editor-exec'd wrappers find their
-            //      runfiles without an out-of-band bootstrap step.
-            match find_runfiles_dir() {
-                Ok(dir) => {
-                    let manifest_path = dir.join("MANIFEST");
-                    if manifest_path.exists() {
-                        Self::create_manifest_based(&manifest_path)?
-                    } else {
-                        Mode::DirectoryBased(dir)
-                    }
-                }
-                Err(_) => match find_runfiles_manifest_from_argv0() {
-                    Some(manifest_path) => Self::create_manifest_based(&manifest_path)?,
-                    None => return Err(RunfilesError::RunfilesDirNotFound),
-                },
-            }
-        };
-
-        let repo_mapping = raw_rlocation(&mode, "_repo_mapping")
-            // This is the only place directory based runfiles might do file IO for a runfile. In the
-            // event that a `_repo_mapping` file does not exist, a default map should be created. Otherwise
-            // if the file is known to exist, parse it and raise errors for users should parsing fail.
-            .filter(|f| f.exists())
-            .map(parse_repo_mapping)
-            .transpose()?
-            .unwrap_or_default();
-
-        Ok(Runfiles { mode, repo_mapping })
+    /// Returns a new [`RunfilesBuilder`]. See its methods for the available
+    /// knobs; [`RunfilesBuilder::build`] with no source set is equivalent
+    /// to [`Runfiles::create`].
+    pub fn builder() -> RunfilesBuilder {
+        RunfilesBuilder::default()
     }
 
-    fn create_manifest_based(manifest_path: &Path) -> Result<Mode> {
-        let manifest_content = std::fs::read_to_string(manifest_path)
-            .map_err(RunfilesError::RunfilesManifestIoError)?;
-        let path_mapping = manifest_content
-            .lines()
-            .flat_map(|line| {
-                let raw_pair = line
-                    .strip_prefix(' ')
-                    .unwrap_or(line)
-                    .split_once(' ')
-                    .ok_or(RunfilesError::RunfilesManifestInvalidFormat)?;
-                let pair = if line.starts_with(' ') {
-                    // Unescape according to SourceManifestAction.java.
-                    // https://github.com/bazelbuild/bazel/blob/3cb75e7bb181e3fb2b33707c172bf80431dc4712/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java#L77-L84
-                    (
-                        raw_pair
-                            .0
-                            .replace("\\s", " ")
-                            .replace("\\n", "\n")
-                            .replace("\\b", "\\")
-                            .into(),
-                        raw_pair.1.replace("\\n", "\n").replace("\\b", "\\").into(),
-                    )
-                } else {
-                    (raw_pair.0.into(), raw_pair.1.into())
-                };
-                Ok::<(PathBuf, PathBuf), RunfilesError>(pair)
-            })
-            .collect::<HashMap<_, _>>();
-        Ok(Mode::ManifestBased(path_mapping))
+    /// Discovers a runfiles source from the process environment and loads
+    /// `_repo_mapping` if present. Equivalent to `Runfiles::builder().build()`.
+    ///
+    /// Discovery order: `RUNFILES_MANIFEST_FILE`, then a `RUNFILES_DIR` /
+    /// `TEST_SRCDIR` / `<argv0>.runfiles` directory (with an inner `MANIFEST`
+    /// preferred when present), then a `<argv0>.runfiles_manifest` sibling.
+    pub fn create() -> Result<Self> {
+        Self::builder().build()
     }
 
     /// Returns the runtime path of a runfile.
@@ -335,6 +261,145 @@ impl Runfiles {
     }
 }
 
+/// Builder for [`Runfiles`]. Construct via [`Runfiles::builder`].
+///
+/// Any unset knob falls back to the same behavior as [`Runfiles::create`]:
+/// [`build`](RunfilesBuilder::build) with no source runs process-based
+/// discovery, and with no `repo_mapping` reads `_repo_mapping` from the
+/// resolved runfiles tree if present.
+#[derive(Default)]
+pub struct RunfilesBuilder {
+    source: Option<Source>,
+    repo_mapping: Option<String>,
+}
+
+enum Source {
+    Directory(PathBuf),
+    Manifest(HashMap<PathBuf, PathBuf>),
+}
+
+impl RunfilesBuilder {
+    /// Use this directory as the runfiles root, skipping discovery. Suitable
+    /// for platforms without env vars, argv, or a discoverable filesystem
+    /// (notably `wasm32-unknown-unknown`, where the host locates the tree).
+    pub fn directory(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.source = Some(Source::Directory(dir.into()));
+        self
+    }
+
+    /// Use this in-memory manifest as the runfiles source, skipping discovery.
+    /// The content follows Bazel's `SourceManifestAction` format.
+    pub fn manifest(mut self, content: impl AsRef<str>) -> Self {
+        self.source = Some(Source::Manifest(parse_manifest(content.as_ref())));
+        self
+    }
+
+    /// Override the `_repo_mapping` file contents. When unset, [`build`](Self::build)
+    /// reads `_repo_mapping` from the resolved runfiles tree if it exists.
+    pub fn repo_mapping(mut self, mapping: impl Into<String>) -> Self {
+        self.repo_mapping = Some(mapping.into());
+        self
+    }
+
+    pub fn build(self) -> Result<Runfiles> {
+        let mode = match self.source {
+            Some(Source::Directory(dir)) => Mode::DirectoryBased(dir),
+            Some(Source::Manifest(map)) => Mode::ManifestBased(map),
+            None => discover_mode()?,
+        };
+
+        let repo_mapping = match self.repo_mapping {
+            Some(content) => parse_repo_mapping_str(&content)?,
+            // No override: try to load `_repo_mapping` from the resolved tree.
+            // `.exists()` returns false on platforms without a real fs (wasm),
+            // so this cleanly no-ops instead of erroring.
+            None => raw_rlocation(&mode, "_repo_mapping")
+                .filter(|f| f.exists())
+                .map(parse_repo_mapping)
+                .transpose()?
+                .unwrap_or_default(),
+        };
+
+        Ok(Runfiles { mode, repo_mapping })
+    }
+}
+
+fn discover_mode() -> Result<Mode> {
+    if let Some(manifest_file) = std::env::var_os(MANIFEST_FILE_ENV_VAR).filter(|v| !v.is_empty()) {
+        return read_manifest_file(Path::new(&manifest_file));
+    }
+
+    // Bazel itself does not publish a normative spec for how a runfiles
+    // library resolves runfiles when none of the documented env vars
+    // (`RUNFILES_MANIFEST_FILE`, `RUNFILES_DIR`, `TEST_SRCDIR`) are set —
+    // see <https://bazel.build/concepts/runfiles> and
+    // <https://bazel.build/reference/test-encyclopedia>, which describe
+    // the env vars and the runfiles tree but leave discovery to each
+    // language's library. What Bazel *does* guarantee on the producer
+    // side is that every binary action writes a `<binary>.runfiles_manifest`
+    // text file next to the output, and that `bazel run` / `bazel test`
+    // additionally materialize a `<binary>.runfiles/` directory.
+    //
+    // Resolution order:
+    //   1. Whatever `find_runfiles_dir()` returns (env vars,
+    //      `<argv0>.runfiles/` sibling walk, or the `.runfiles` ancestor
+    //      walk). If it returns a directory containing a `MANIFEST`,
+    //      prefer that; otherwise use the dir.
+    //   2. Fall back to `<argv0>.runfiles_manifest` — the file Bazel
+    //      writes on every build action, even when no `bazel run`
+    //      invocation materialized the directory. This is what lets
+    //      editor-exec'd wrappers find their runfiles without an
+    //      out-of-band bootstrap step.
+    match find_runfiles_dir() {
+        Ok(dir) => {
+            let manifest_path = dir.join("MANIFEST");
+            if manifest_path.exists() {
+                read_manifest_file(&manifest_path)
+            } else {
+                Ok(Mode::DirectoryBased(dir))
+            }
+        }
+        Err(_) => match find_runfiles_manifest_from_argv0() {
+            Some(manifest_path) => read_manifest_file(&manifest_path),
+            None => Err(RunfilesError::RunfilesDirNotFound),
+        },
+    }
+}
+
+fn read_manifest_file(path: &Path) -> Result<Mode> {
+    let content = std::fs::read_to_string(path).map_err(RunfilesError::RunfilesManifestIoError)?;
+    Ok(Mode::ManifestBased(parse_manifest(&content)))
+}
+
+fn parse_manifest(content: &str) -> HashMap<PathBuf, PathBuf> {
+    content
+        .lines()
+        .flat_map(|line| {
+            let raw_pair = line
+                .strip_prefix(' ')
+                .unwrap_or(line)
+                .split_once(' ')
+                .ok_or(RunfilesError::RunfilesManifestInvalidFormat)?;
+            let pair = if line.starts_with(' ') {
+                // Unescape according to SourceManifestAction.java.
+                // https://github.com/bazelbuild/bazel/blob/3cb75e7bb181e3fb2b33707c172bf80431dc4712/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java#L77-L84
+                (
+                    raw_pair
+                        .0
+                        .replace("\\s", " ")
+                        .replace("\\n", "\n")
+                        .replace("\\b", "\\")
+                        .into(),
+                    raw_pair.1.replace("\\n", "\n").replace("\\b", "\\").into(),
+                )
+            } else {
+                (raw_pair.0.into(), raw_pair.1.into())
+            };
+            Ok::<(PathBuf, PathBuf), RunfilesError>(pair)
+        })
+        .collect::<HashMap<_, _>>()
+}
+
 fn raw_rlocation(mode: &Mode, path: impl AsRef<Path>) -> Option<PathBuf> {
     let path = path.as_ref();
     match mode {
@@ -344,13 +409,15 @@ fn raw_rlocation(mode: &Mode, path: impl AsRef<Path>) -> Option<PathBuf> {
 }
 
 fn parse_repo_mapping(path: PathBuf) -> Result<RepoMapping> {
+    let content = std::fs::read_to_string(path).map_err(RunfilesError::RepoMappingIoError)?;
+    parse_repo_mapping_str(&content)
+}
+
+fn parse_repo_mapping_str(content: &str) -> Result<RepoMapping> {
     let mut exact = HashMap::new();
     let mut prefixes = BTreeMap::new();
 
-    for line in std::fs::read_to_string(path)
-        .map_err(RunfilesError::RepoMappingIoError)?
-        .lines()
-    {
+    for line in content.lines() {
         let parts: Vec<&str> = line.splitn(3, ',').collect();
         if parts.len() < 3 {
             return Err(RunfilesError::RepoMappingInvalidFormat);
@@ -395,6 +462,7 @@ fn parse_repo_mapping(path: PathBuf) -> Result<RepoMapping> {
 ///
 /// Returns `None` when no manifest file exists (in which case callers
 /// fall through to `find_runfiles_dir`).
+#[cfg(not(target_family = "wasm"))]
 fn find_runfiles_manifest_from_argv0() -> Option<PathBuf> {
     let argv0 = std::env::args_os().next()?;
     let argv0_path = PathBuf::from(&argv0);
@@ -412,8 +480,14 @@ fn find_runfiles_manifest_from_argv0() -> Option<PathBuf> {
     find_runfiles_manifest_for(&exe)
 }
 
+#[cfg(target_family = "wasm")]
+fn find_runfiles_manifest_from_argv0() -> Option<PathBuf> {
+    None
+}
+
 /// Inner helper for [`find_runfiles_manifest_from_argv0`] that takes an
 /// explicit binary path so it's testable without controlling argv[0].
+#[cfg(not(target_family = "wasm"))]
 fn find_runfiles_manifest_for(exe_path: &Path) -> Option<PathBuf> {
     let dir = exe_path.parent()?;
     let file_name = exe_path.file_name()?;
@@ -445,6 +519,11 @@ pub fn find_runfiles_dir() -> Result<PathBuf> {
         }
     }
 
+    find_runfiles_dir_from_argv0()
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn find_runfiles_dir_from_argv0() -> Result<PathBuf> {
     // Consume the first argument (argv[0])
     let exec_path = std::env::args().next().expect("arg 0 was not set");
 
@@ -496,6 +575,12 @@ pub fn find_runfiles_dir() -> Result<PathBuf> {
         }
     }
 
+    Err(RunfilesError::RunfilesDirNotFound)
+}
+
+/// wasm has no `argv[0]` or symlink resolution to work with.
+#[cfg(target_family = "wasm")]
+fn find_runfiles_dir_from_argv0() -> Result<PathBuf> {
     Err(RunfilesError::RunfilesDirNotFound)
 }
 
@@ -1003,5 +1088,74 @@ mod test {
         let result = r.rlocation_from("aaa/path", "+other+repo");
         // Should fall back to the path as-is
         assert_eq!(result, Some(runfiles_dir.join("aaa/path")));
+    }
+
+    #[test]
+    fn test_builder_directory() {
+        let runfiles_dir = make_runfiles_like_dir("test_builder_directory");
+
+        let r = Runfiles::builder()
+            .directory(&runfiles_dir)
+            .build()
+            .unwrap();
+
+        let f = rlocation!(r, "rules_rust/rust/runfiles/data/sample.txt").unwrap();
+        let mut file = File::open(&f)
+            .unwrap_or_else(|e| panic!("Failed to open file: {}\n{:?}", f.display(), e));
+        let mut buffer = String::new();
+        file.read_to_string(&mut buffer).unwrap();
+        assert_eq!("Example Text!", buffer);
+    }
+
+    /// Point the builder at a nonexistent root and confirm construction
+    /// still succeeds — the builder must not touch the fs when a source is set.
+    #[test]
+    fn test_builder_directory_does_not_touch_fs() {
+        let r = Runfiles::builder()
+            .directory("/definitely/does/not/exist/for/runfiles")
+            .build()
+            .unwrap();
+
+        let p = r.rlocation("some/workspace/data.txt").unwrap();
+        assert_eq!(
+            p,
+            PathBuf::from("/definitely/does/not/exist/for/runfiles/some/workspace/data.txt")
+        );
+    }
+
+    #[test]
+    fn test_builder_manifest() {
+        let r = Runfiles::builder()
+            .manifest("a/b c/d\n empty-file \n")
+            .build()
+            .unwrap();
+        assert_eq!(r.rlocation("a/b"), Some(PathBuf::from("c/d")));
+        assert_eq!(r.rlocation("empty-file"), Some(PathBuf::from("")));
+        assert_eq!(r.rlocation("does/not/exist"), None);
+    }
+
+    #[test]
+    fn test_builder_manifest_with_repo_mapping() {
+        let r = Runfiles::builder()
+            .manifest("canonical/x/y actual/x/y\n")
+            .repo_mapping("source_repo,apparent_name,canonical\n")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            r.rlocation_from("apparent_name/x/y", "source_repo"),
+            Some(PathBuf::from("actual/x/y"))
+        );
+        assert_eq!(r.rlocation_from("apparent_name/x/y", "other_repo"), None);
+    }
+
+    #[test]
+    fn test_builder_rejects_invalid_repo_mapping() {
+        let err = Runfiles::builder()
+            .directory("/tmp")
+            .repo_mapping("not,enough")
+            .build()
+            .expect_err("Should have failed with an invalid repo mapping");
+        assert_eq!(err, RunfilesError::RepoMappingInvalidFormat);
     }
 }


### PR DESCRIPTION
This change aims to enable the use of the runfiles library on environments like `wasm` where `fs` and `env` support is limited. The builder allows for more explicit control over the construction of a `Runfiles` instance.