### PR TITLE
Unconditionally set static_library even when use_pic is True

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2315,10 +2315,9 @@ def establish_cc_info(ctx, attr, crate_info, toolchain, cc_toolchain, feature_co
     if crate_info.type == "staticlib":
         if cc_toolchain:
             kwargs = {}
+            kwargs["static_library"] = crate_info.output
             if use_pic:
                 kwargs["pic_static_library"] = crate_info.output
-            else:
-                kwargs["static_library"] = crate_info.output
 
             library_to_link = cc_common.create_library_to_link(
                 actions = ctx.actions,
@@ -2335,10 +2334,9 @@ def establish_cc_info(ctx, attr, crate_info, toolchain, cc_toolchain, feature_co
 
         if cc_toolchain:
             kwargs = {}
+            kwargs["static_library"] = dot_a
             if use_pic:
                 kwargs["pic_static_library"] = dot_a
-            else:
-                kwargs["static_library"] = dot_a
 
             library_to_link = cc_common.create_library_to_link(
                 actions = ctx.actions,

--- a/test/unit/cc_info/cc_info_test.bzl
+++ b/test/unit/cc_info/cc_info_test.bzl
@@ -42,12 +42,10 @@ def _assert_cc_info_has_library_to_link(env, tut, type, ccinfo_count):
         asserts.equals(env, None, library_to_link.interface_library)
         asserts.equals(env, None, library_to_link.resolved_symlink_dynamic_library)
         asserts.equals(env, None, library_to_link.resolved_symlink_interface_library)
-        if library_to_link.static_library != None:
-            if type in ("rlib", "lib"):
-                asserts.true(env, library_to_link.static_library.basename.startswith("lib" + tut.label.name))
-            asserts.equals(env, None, library_to_link.pic_static_library)
-        else:
-            asserts.true(env, library_to_link.pic_static_library != None)
+        asserts.true(env, library_to_link.static_library != None)
+        if type in ("rlib", "lib"):
+            asserts.true(env, library_to_link.static_library.basename.startswith("lib" + tut.label.name))
+        if library_to_link.pic_static_library != None:
             if type in ("rlib", "lib"):
                 asserts.true(env, library_to_link.pic_static_library.basename.startswith("lib" + tut.label.name))
 


### PR DESCRIPTION
`rules_go` and some other C++ interoperability layers expect static_library to unconditionally be present. When they attempt to link the binary, the Rust archives (libcxx.a, libtokenizers_cpp.a, etc.) were missing from the linker command line, triggering the `ld.lld: error: undefined symbol` build failure, we therefore set those unconditionally.