### PR TITLE
release: remove WORKSPACE snippets from release notes template

### DIFF
--- a/.github/release_notes.template
+++ b/.github/release_notes.template
@@ -8,17 +8,6 @@ Additional documentation can be found at: https://bazelbuild.github.io/rules_rus
 bazel_dep(name = "rules_rust", version = "{version}")
 ```
 
-## WORKSPACE
-
-```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "rules_rust",
-    integrity = "sha256-{sha256_base64}",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/{version}/rules_rust-{version}.tar.gz"],
-)
-```
-
 ## Extensions
 
 <details>
@@ -33,18 +22,6 @@ http_archive(
 bazel_dep(name = "rules_rust_bindgen", version = "{version}")
 ```
 
-#### WORKSPACE
-
-```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "rules_rust_bindgen",
-    integrity = "sha256-{sha256_base64}",
-    strip_prefix = "extensions/bindgen",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/{version}/rules_rust-{version}.tar.gz"],
-)
-```
-
 </details>
 
 ### MdBook
@@ -55,18 +32,6 @@ http_archive(
 
 ```python
 bazel_dep(name = "rules_rust_mdbook", version = "{version}")
-```
-
-#### WORKSPACE
-
-```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "rules_rust_mdbook",
-    integrity = "sha256-{sha256_base64}",
-    strip_prefix = "extensions/mdbook",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/{version}/rules_rust-{version}.tar.gz"],
-)
 ```
 
 </details>
@@ -81,17 +46,7 @@ http_archive(
 bazel_dep(name = "rules_rust_prost", version = "{version}")
 ```
 
-#### WORKSPACE
-
-```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "rules_rust_prost",
-    integrity = "sha256-{sha256_base64}",
-    strip_prefix = "extensions/prost",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/{version}/rules_rust-{version}.tar.gz"],
-)
-```
+</details>
 
 ### PyO3
 
@@ -111,18 +66,6 @@ bazel_dep(name = "rules_rust_pyo3", version = "{version}")
 
 ```python
 bazel_dep(name = "rules_rust_wasm_bindgen", version = "{version}")
-```
-
-#### WORKSPACE
-
-```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "rules_rust_wasm_bindgen",
-    integrity = "sha256-{sha256_base64}",
-    strip_prefix = "extensions/wasm_bindgen",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/{version}/rules_rust-{version}.tar.gz"],
-)
 ```
 
 </details>


### PR DESCRIPTION
## Summary

WORKSPACE support was removed in #4005 (released in 0.71.0). The release notes template was not updated at the time, so every release since 0.71.0 (0.71.0, 0.71.1, 0.71.2, 0.71.3, 0.72.0) has advertised `http_archive` WORKSPACE snippets that don't work.

This removes all WORKSPACE sections from the template so future release notes only show the Bzlmod setup.

Also fixes a pre-existing missing `</details>` closing tag in the Prost extension section.