### PR TITLE
fix(crate_universe): pass OUTPUT_BASE as --output_base startup flag to bazel info

### DIFF
--- a/crate_universe/src/cli/vendor.rs
+++ b/crate_universe/src/cli/vendor.rs
@@ -155,8 +155,14 @@ struct BazelInfo {
 impl BazelInfo {
     /// Construct a new struct based on the current binary and workspace paths provided.
     fn try_new(bazel: &Path, workspace_dir: &Path) -> anyhow::Result<Self> {
-        let output = process::Command::new(bazel)
-            .current_dir(workspace_dir)
+        let mut cmd = process::Command::new(bazel);
+        cmd.current_dir(workspace_dir);
+        // Pass --output_base as a Bazel startup flag so it never touches the
+        // default (possibly non-writable) output_base path.
+        if let Ok(output_base) = env::var("OUTPUT_BASE") {
+            cmd.arg("--output_base").arg(output_base);
+        }
+        let output = cmd
             .arg("info")
             .arg("release")
             .arg("output_base")
@@ -171,10 +177,9 @@ impl BazelInfo {
         Self::parse_bazel_info(&output)
     }
 
-    /// Parse `bazel info` output into a `BazelInfo`. The `OUTPUT_BASE`
-    /// environment variable, when set, overrides the parsed output_base.
+    /// Parse `bazel info` output into a `BazelInfo`.
     fn parse_bazel_info(output: &str) -> anyhow::Result<Self> {
-        let mut bazel_info: HashMap<String, String> = output
+        let bazel_info: HashMap<String, String> = output
             .trim()
             .split('\n')
             .map(|line| {
@@ -185,12 +190,6 @@ impl BazelInfo {
                 Ok((k.to_string(), (v[1..]).trim().to_string()))
             })
             .collect::<anyhow::Result<HashMap<_, _>>>()?;
-
-        // Allow a predefined environment variable to take precedent. This
-        // solves for the specific needs of Bazel CI on Github.
-        if let Ok(path) = env::var("OUTPUT_BASE") {
-            bazel_info.insert("output_base".to_owned(), path);
-        };
 
         BazelInfo::try_from(bazel_info)
     }
@@ -414,22 +413,5 @@ mod tests {
             info.release
         );
         assert_eq!(PathBuf::from("/tmp/output_base"), info.output_base);
-    }
-
-    #[test]
-    fn test_parse_bazel_info_output_base_env_override() {
-        let bazel_info_output = "release: 8.0.0\noutput_base: /original/path";
-
-        // Without OUTPUT_BASE set, parse_bazel_info uses the parsed value.
-        env::remove_var("OUTPUT_BASE");
-        let info = BazelInfo::parse_bazel_info(bazel_info_output).unwrap();
-        assert_eq!(PathBuf::from("/original/path"), info.output_base);
-
-        // With OUTPUT_BASE set, it overrides the parsed value.
-        env::set_var("OUTPUT_BASE", "/override/path");
-        let info = BazelInfo::parse_bazel_info(bazel_info_output).unwrap();
-        assert_eq!(PathBuf::from("/override/path"), info.output_base);
-
-        env::remove_var("OUTPUT_BASE");
     }
 }


### PR DESCRIPTION
## Problem

The `OUTPUT_BASE` env var was added to let CI environments supply the output_base without relying on `bazel info`. However, the override is applied **after** parsing the `bazel info` output:

```rust
let output = process::Command::new(bazel).arg("info")...output()?;
if !output.status.success() {
    bail!(output.status)    // <-- bails here when output_base is not writable
}
// ... parse output ...
if let Ok(path) = env::var("OUTPUT_BASE") {  // <-- never reached
    bazel_info.insert(...);
}
```

When `bazel info` fails (e.g. the default `~/.cache/bazel/...` is not writable in a sandboxed CI), the function bails before `OUTPUT_BASE` is ever checked — making the env var useless for its intended purpose.

## Fix

Pass `OUTPUT_BASE` as a `--output_base` Bazel **startup flag** (before the subcommand):

```
bazel --output_base=/path/to/base info release output_base
```

Startup flags take effect before Bazel accesses any path, so it never touches the default (possibly non-writable) output_base. The `bazel info` subprocess runs normally and the post-parsing override is no longer needed.

## Changes

- `crate_universe/src/cli/vendor.rs`: restructure `BazelInfo::try_new` to optionally inject `--output_base` as a startup flag; remove the post-parsing `OUTPUT_BASE` override.
- Removed `test_parse_bazel_info_output_base_env_override` since `parse_bazel_info` no longer handles the `OUTPUT_BASE` override — the existing `test_bazel_info` already covers the parsing logic.