### PR TITLE
Set `toolchain` parameter to `toolchain_type` instead of `None`

### DIFF
--- a/extensions/bindgen/private/bindgen.bzl
+++ b/extensions/bindgen/private/bindgen.bzl
@@ -412,9 +412,7 @@ def _rust_bindgen_impl(ctx):
         env = env,
         arguments = [args],
         tools = tools,
-        # ctx.actions.run now require (through a buildifier check) that we
-        # specify this
-        toolchain = None,
+        toolchain = "@rules_rust_bindgen//:toolchain_type",
     )
 
     if ctx.attr.merge_cc_lib_objects_into_rlib:


### PR DESCRIPTION
I don't understand the exact mechanics of this, but it appears to be necessary to support multiple different exec configurations.