### PR TITLE
Check for nightly toolchain when enabling split debug info.

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1778,13 +1778,23 @@ def rustc_compile_action(
         elif ctx.attr.require_explicit_unstable_features == -1:
             require_explicit_unstable_features = toolchain.require_explicit_unstable_features
 
-    use_split_debuginfo = (
+    use_split_debuginfo = False
+    if (
         feature_configuration and
         cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "per_object_debug_info") and
-        ctx.fragments.cpp.fission_active_for_current_compilation_mode() and
+        ctx.fragments.cpp.fission_active_for_current_compilation_mode()
+    ):
         # `-Zsplit-dwarf-out-dir` is only available on nightly.
-        toolchain.channel == "nightly"
-    )
+        if toolchain.channel == "nightly":
+            use_split_debuginfo = True
+        elif toolchain._skip_fission_for_rust:
+            use_split_debuginfo = False
+        else:
+            fail(
+                "Split debug info (fission) was requested, but `-Zsplit-dwarf-out-dir` requires a nightly Rust toolchain " +
+                "(current toolchain channel is \"{}\"). ".format(toolchain.channel) +
+                "To skip fission for Rust objects and suppress this error, set `--@rules_rust//rust/settings:skip_fission_for_rust`.",
+            )
     if use_split_debuginfo:
         rust_flags = rust_flags + [
             "--codegen=split-debuginfo=unpacked",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1784,11 +1784,10 @@ def rustc_compile_action(
         cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "per_object_debug_info") and
         ctx.fragments.cpp.fission_active_for_current_compilation_mode()
     ):
-        # `-Zsplit-dwarf-out-dir` is only available on nightly.
-        if toolchain.channel == "nightly":
-            use_split_debuginfo = True
-        elif toolchain._skip_fission_for_rust:
+        if toolchain._skip_fission_for_rust:
             use_split_debuginfo = False
+        elif toolchain.channel == "nightly":
+            use_split_debuginfo = True
         else:
             fail(
                 "Split debug info (fission) was requested, but `-Zsplit-dwarf-out-dir` requires a nightly Rust toolchain " +

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1781,7 +1781,9 @@ def rustc_compile_action(
     use_split_debuginfo = (
         feature_configuration and
         cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "per_object_debug_info") and
-        ctx.fragments.cpp.fission_active_for_current_compilation_mode()
+        ctx.fragments.cpp.fission_active_for_current_compilation_mode() and
+        # `-Zsplit-dwarf-out-dir` is only available on nightly.
+        toolchain.channel == "nightly"
     )
     if use_split_debuginfo:
         rust_flags = rust_flags + [

--- a/rust/private/toolchain.bzl
+++ b/rust/private/toolchain.bzl
@@ -888,9 +888,6 @@ rust_toolchain = rule(
         "_experimental_compile_rustdoc_tests": attr.label(
             default = Label("//rust/settings:experimental_compile_rustdoc_tests"),
         ),
-        "_skip_fission_for_rust": attr.label(
-            default = Label("//rust/settings:skip_fission_for_rust"),
-        ),
         "_experimental_use_allocator_libraries_with_mangled_symbols_setting": attr.label(
             default = Label("//rust/settings:experimental_use_allocator_libraries_with_mangled_symbols"),
             providers = [BuildSettingInfo],
@@ -928,6 +925,9 @@ rust_toolchain = rule(
         ),
         "_rename_first_party_crates": attr.label(
             default = Label("//rust/settings:rename_first_party_crates"),
+        ),
+        "_skip_fission_for_rust": attr.label(
+            default = Label("//rust/settings:skip_fission_for_rust"),
         ),
         "_third_party_dir": attr.label(
             default = Label("//rust/settings:third_party_dir"),

--- a/rust/private/toolchain.bzl
+++ b/rust/private/toolchain.bzl
@@ -647,6 +647,7 @@ def _rust_toolchain_impl(ctx):
         _experimental_use_cc_common_link = _experimental_use_cc_common_link(ctx),
         _experimental_use_global_allocator = experimental_use_global_allocator,
         _experimental_compile_rustdoc_tests = ctx.attr._experimental_compile_rustdoc_tests[BuildSettingInfo].value,
+        _skip_fission_for_rust = ctx.attr._skip_fission_for_rust[BuildSettingInfo].value,
         _experimental_use_coverage_metadata_files = ctx.attr._experimental_use_coverage_metadata_files[BuildSettingInfo].value,
         _toolchain_generated_sysroot = ctx.attr._toolchain_generated_sysroot[BuildSettingInfo].value,
         _incompatible_do_not_include_data_in_compile_data = ctx.attr._incompatible_do_not_include_data_in_compile_data[IncompatibleFlagInfo].enabled,
@@ -886,6 +887,9 @@ rust_toolchain = rule(
         ),
         "_experimental_compile_rustdoc_tests": attr.label(
             default = Label("//rust/settings:experimental_compile_rustdoc_tests"),
+        ),
+        "_skip_fission_for_rust": attr.label(
+            default = Label("//rust/settings:skip_fission_for_rust"),
         ),
         "_experimental_use_allocator_libraries_with_mangled_symbols_setting": attr.label(
             default = Label("//rust/settings:experimental_use_allocator_libraries_with_mangled_symbols"),

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -36,6 +36,7 @@ load(
     "require_explicit_unstable_features",
     "rustc_output_diagnostics",
     "rustfmt_toml",
+    "skip_fission_for_rust",
     "third_party_dir",
     "toolchain_generated_sysroot",
     "toolchain_linker_preference",
@@ -140,3 +141,5 @@ toolchain_linker_preference()
 unpretty()
 
 zself_profile_events()
+
+skip_fission_for_rust()

--- a/rust/settings/settings.bzl
+++ b/rust/settings/settings.bzl
@@ -584,3 +584,11 @@ def zself_profile_events(name = "zself_profile_events"):
         name = name,
         build_setting_default = [],
     )
+
+def skip_fission_for_rust():
+    """A flag to skip split debug info (Fission) for Rust objects when using a non-nightly toolchain.
+    """
+    bool_flag(
+        name = "skip_fission_for_rust",
+        build_setting_default = False,
+    )

--- a/test/unit/debug_info/debug_info_analysis_test.bzl
+++ b/test/unit/debug_info/debug_info_analysis_test.bzl
@@ -185,8 +185,8 @@ _FISSION_COMPATIBILITY = ["@platforms//os:linux"] + select({
 })
 
 # `-Zsplit-dwarf-out-dir` requires nightly. When testing split debug info,
-# stable and beta should error out unless `skip_fission_for_rust` is set.
-not_nightly_fission_test = analysistest.make(
+# `skip_fission_for_rust` skips fission on both nightly and non-nightly toolchains.
+skip_fission_test = analysistest.make(
     _no_fission_test_impl,
     config_settings = {
         "//command_line_option:features": ["per_object_debug_info"],
@@ -326,10 +326,15 @@ def debug_info_analysis_test_suite(name):
         name = "lib_no_fission_test",
         target_under_test = ":mylib",
     )
-    not_nightly_fission_test(
-        name = "lib_not_nightly_fission_test",
+    skip_fission_test(
+        name = "lib_skip_fission_test",
         target_under_test = ":mylib",
         target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
+    )
+    skip_fission_test(
+        name = "lib_skip_fission_nightly_test",
+        target_under_test = ":mylib",
+        target_compatible_with = _FISSION_COMPATIBILITY,
     )
     not_nightly_fission_error_test(
         name = "lib_not_nightly_fission_error_test",
@@ -346,10 +351,15 @@ def debug_info_analysis_test_suite(name):
         name = "bin_no_fission_test",
         target_under_test = ":myrustbin",
     )
-    not_nightly_fission_test(
-        name = "bin_not_nightly_fission_test",
+    skip_fission_test(
+        name = "bin_skip_fission_test",
         target_under_test = ":myrustbin",
         target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
+    )
+    skip_fission_test(
+        name = "bin_skip_fission_nightly_test",
+        target_under_test = ":myrustbin",
+        target_compatible_with = _FISSION_COMPATIBILITY,
     )
     not_nightly_fission_error_test(
         name = "bin_not_nightly_fission_error_test",
@@ -366,10 +376,15 @@ def debug_info_analysis_test_suite(name):
         name = "test_no_fission_test",
         target_under_test = ":myrusttest",
     )
-    not_nightly_fission_test(
-        name = "test_not_nightly_fission_test",
+    skip_fission_test(
+        name = "test_skip_fission_test",
         target_under_test = ":myrusttest",
         target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
+    )
+    skip_fission_test(
+        name = "test_skip_fission_nightly_test",
+        target_under_test = ":myrusttest",
+        target_compatible_with = _FISSION_COMPATIBILITY,
     )
     not_nightly_fission_error_test(
         name = "test_not_nightly_fission_error_test",
@@ -385,15 +400,18 @@ def debug_info_analysis_test_suite(name):
             ":test_dsym_test",
             ":lib_fission_test",
             ":lib_no_fission_test",
-            ":lib_not_nightly_fission_test",
+            ":lib_skip_fission_test",
+            ":lib_skip_fission_nightly_test",
             ":lib_not_nightly_fission_error_test",
             ":bin_fission_test",
             ":bin_no_fission_test",
-            ":bin_not_nightly_fission_test",
+            ":bin_skip_fission_test",
+            ":bin_skip_fission_nightly_test",
             ":bin_not_nightly_fission_error_test",
             ":test_fission_test",
             ":test_no_fission_test",
-            ":test_not_nightly_fission_test",
+            ":test_skip_fission_test",
+            ":test_skip_fission_nightly_test",
             ":test_not_nightly_fission_error_test",
         ] + [
             ":lib_pdb_test_{}".format(compilation_mode)

--- a/test/unit/debug_info/debug_info_analysis_test.bzl
+++ b/test/unit/debug_info/debug_info_analysis_test.bzl
@@ -185,11 +185,26 @@ _FISSION_COMPATIBILITY = ["@platforms//os:linux"] + select({
 })
 
 # `-Zsplit-dwarf-out-dir` requires nightly. When testing split debug info,
-# stable and beta should behave the same as `--fission=no` so we reuse the
-# impl of `no_fission_test`.
+# stable and beta should error out unless `skip_fission_for_rust` is set.
 not_nightly_fission_test = analysistest.make(
     _no_fission_test_impl,
     config_settings = {
+        "//command_line_option:features": ["per_object_debug_info"],
+        "//command_line_option:fission": ["yes"],
+        str(Label("//rust/settings:skip_fission_for_rust")): True,
+    },
+)
+
+def _not_nightly_fission_error_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    asserts.expect_failure(env, "skip_fission_for_rust")
+    return analysistest.end(env)
+
+not_nightly_fission_error_test = analysistest.make(
+    _not_nightly_fission_error_test_impl,
+    expect_failure = True,
+    config_settings = {
+        "//command_line_option:features": ["per_object_debug_info"],
         "//command_line_option:fission": ["yes"],
     },
 )
@@ -316,6 +331,11 @@ def debug_info_analysis_test_suite(name):
         target_under_test = ":mylib",
         target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
     )
+    not_nightly_fission_error_test(
+        name = "lib_not_nightly_fission_error_test",
+        target_under_test = ":mylib",
+        target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
+    )
 
     fission_test(
         name = "bin_fission_test",
@@ -328,6 +348,11 @@ def debug_info_analysis_test_suite(name):
     )
     not_nightly_fission_test(
         name = "bin_not_nightly_fission_test",
+        target_under_test = ":myrustbin",
+        target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
+    )
+    not_nightly_fission_error_test(
+        name = "bin_not_nightly_fission_error_test",
         target_under_test = ":myrustbin",
         target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
     )
@@ -346,6 +371,11 @@ def debug_info_analysis_test_suite(name):
         target_under_test = ":myrusttest",
         target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
     )
+    not_nightly_fission_error_test(
+        name = "test_not_nightly_fission_error_test",
+        target_under_test = ":myrusttest",
+        target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
+    )
 
     native.test_suite(
         name = name,
@@ -355,10 +385,16 @@ def debug_info_analysis_test_suite(name):
             ":test_dsym_test",
             ":lib_fission_test",
             ":lib_no_fission_test",
+            ":lib_not_nightly_fission_test",
+            ":lib_not_nightly_fission_error_test",
             ":bin_fission_test",
             ":bin_no_fission_test",
+            ":bin_not_nightly_fission_test",
+            ":bin_not_nightly_fission_error_test",
             ":test_fission_test",
             ":test_no_fission_test",
+            ":test_not_nightly_fission_test",
+            ":test_not_nightly_fission_error_test",
         ] + [
             ":lib_pdb_test_{}".format(compilation_mode)
             for compilation_mode in pdb_file_tests

--- a/test/unit/debug_info/debug_info_analysis_test.bzl
+++ b/test/unit/debug_info/debug_info_analysis_test.bzl
@@ -184,6 +184,22 @@ _FISSION_COMPATIBILITY = ["@platforms//os:linux"] + select({
     "//conditions:default": ["@platforms//:incompatible"],
 })
 
+# `-Zsplit-dwarf-out-dir` requires nightly. When testing split debug info,
+# stable and beta should behave the same as `--fission=no` so we reuse the
+# impl of `no_fission_test`.
+not_nightly_fission_test = analysistest.make(
+    _no_fission_test_impl,
+    config_settings = {
+        "//command_line_option:fission": ["yes"],
+    },
+)
+
+_NOT_NIGHTLY_COMPATIBILITY = ["@platforms//os:linux"] + select({
+    "//rust/toolchain/channel:stable": [],
+    "//rust/toolchain/channel:beta": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
 def debug_info_analysis_test_suite(name):
     """Analysis tests for debug info in cdylib and bin targets.
 
@@ -295,6 +311,11 @@ def debug_info_analysis_test_suite(name):
         name = "lib_no_fission_test",
         target_under_test = ":mylib",
     )
+    not_nightly_fission_test(
+        name = "lib_not_nightly_fission_test",
+        target_under_test = ":mylib",
+        target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
+    )
 
     fission_test(
         name = "bin_fission_test",
@@ -305,6 +326,11 @@ def debug_info_analysis_test_suite(name):
         name = "bin_no_fission_test",
         target_under_test = ":myrustbin",
     )
+    not_nightly_fission_test(
+        name = "bin_not_nightly_fission_test",
+        target_under_test = ":myrustbin",
+        target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
+    )
 
     fission_test(
         name = "test_fission_test",
@@ -314,6 +340,11 @@ def debug_info_analysis_test_suite(name):
     no_fission_test(
         name = "test_no_fission_test",
         target_under_test = ":myrusttest",
+    )
+    not_nightly_fission_test(
+        name = "test_not_nightly_fission_test",
+        target_under_test = ":myrusttest",
+        target_compatible_with = _NOT_NIGHTLY_COMPATIBILITY,
     )
 
     native.test_suite(

--- a/test/unit/debug_info/debug_info_analysis_test.bzl
+++ b/test/unit/debug_info/debug_info_analysis_test.bzl
@@ -195,8 +195,8 @@ not_nightly_fission_test = analysistest.make(
 )
 
 _NOT_NIGHTLY_COMPATIBILITY = ["@platforms//os:linux"] + select({
-    "//rust/toolchain/channel:stable": [],
     "//rust/toolchain/channel:beta": [],
+    "//rust/toolchain/channel:stable": [],
     "//conditions:default": ["@platforms//:incompatible"],
 })
 


### PR DESCRIPTION
This fixes a problem pointed out by
https://github.com/bazelbuild/rules_rust/pull/4092#issuecomment-5136906807.

`-Zsplit-dwarf-out-dir` is only available on nightly, so we have to gate split debug info on it. Now, if the user requests `--fission` while using a non-nightly Rust toolchain, the build will fail. To avoid breaking users relying on the previous behavior, a `skip_fission_for_rust` flag has been added. Users can add it to their bazelrc file to explicitly signal that they're okay with Rust compiles not producing split debug info, even if requested in the command line.

Assisted-by: Gemini