### PR TITLE
Fix path mapping for generated linker paths

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1320,7 +1320,19 @@ def construct_arguments(
             )
 
             env.update(link_env)
-            rustc_flags.add(ld, format = "--codegen=linker=%s")
+
+            # Keep generated linker paths File-backed so Bazel can rewrite them.
+            linker = ld
+            if toolchain.linker and ld == toolchain.linker.path:
+                linker = toolchain.linker
+            elif cc_toolchain and ld.startswith("bazel-out/"):
+                linker_files = cc_toolchain._linker_files if hasattr(cc_toolchain, "_linker_files") else cc_toolchain.linker_files()
+                for linker_file in linker_files.to_list():
+                    if linker_file.path == ld or ld.endswith("/" + linker_file.short_path):
+                        linker = linker_file
+                        break
+
+            rustc_flags.add(linker, format = "--codegen=linker=%s")
 
             # Split link args into individual "--codegen=link-arg=" flags to handle nested spaces.
             # Additional context: https://github.com/rust-lang/rust/pull/36574

--- a/test/unit/cc_toolchain_runtime_lib/cc_toolchain_runtime_lib_test.bzl
+++ b/test/unit/cc_toolchain_runtime_lib/cc_toolchain_runtime_lib_test.bzl
@@ -3,11 +3,14 @@ Tests for handling of cc_toolchain's static_runtime_lib/dynamic_runtime_lib.
 """
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("@rules_cc//cc:cc_toolchain_config_lib.bzl", "feature")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:cc_toolchain_config_lib.bzl", "action_config", "feature", "tool")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
 load("//rust:defs.bzl", "rust_shared_library", "rust_static_library")
+load("//test/unit:common.bzl", "get_bin_dir_from_action")
 
 def _test_cc_config_impl(ctx):
     config_info = cc_common.create_cc_toolchain_config_info(
@@ -20,6 +23,16 @@ def _test_cc_config_impl(ctx):
         compiler = "unknown",
         abi_version = "unknown",
         abi_libc_version = "unknown",
+        action_configs = [
+            action_config(
+                action_name = action_name,
+                tools = [tool(tool = ctx.file.linker)],
+            )
+            for action_name in [
+                ACTION_NAMES.cpp_link_dynamic_library,
+                ACTION_NAMES.cpp_link_static_library,
+            ]
+        ],
         features = [
             feature(name = "static_link_cpp_runtimes", enabled = True),
         ],
@@ -28,6 +41,7 @@ def _test_cc_config_impl(ctx):
 
 test_cc_config = rule(
     implementation = _test_cc_config_impl,
+    attrs = {"linker": attr.label(allow_single_file = True)},
     provides = [CcToolchainConfigInfo],
 )
 
@@ -71,6 +85,16 @@ def _inputs_analysis_test_impl(ctx):
             "error: expected '{}' to be in inputs: '{}'".format(expected, inputs),
         )
 
+    linker_files = [file for file in inputs if file.basename == "link-wrapper"]
+    asserts.equals(env, 1, len(linker_files))
+
+    linker_args = [arg for arg in action.argv if arg.startswith("--codegen=linker=")]
+    asserts.equals(env, 1, len(linker_args))
+
+    bin_dir = get_bin_dir_from_action(action)
+    linker_path = "{}/{}".format(bin_dir, linker_files[0].short_path) if bin_dir == "bazel-out/cfg/bin" else linker_files[0].path
+    asserts.equals(env, "--codegen=linker={}".format(linker_path), linker_args[0])
+
     return analysistest.end(env)
 
 inputs_analysis_test = analysistest.make(
@@ -88,15 +112,23 @@ def runtime_libs_test(name):
       name: The name of the test target.
     """
 
+    write_file(
+        name = "%s/linker" % name,
+        out = "%s/link-wrapper" % name,
+        content = ["#!/bin/sh", "exit 0"],
+        is_executable = True,
+    )
+
     test_cc_config(
         name = "%s/cc_toolchain_config" % name,
+        linker = ":%s/linker" % name,
     )
     cc_toolchain(
         name = "%s/test_cc_toolchain_impl" % name,
         all_files = ":empty",
         compiler_files = ":empty",
         dwp_files = ":empty",
-        linker_files = ":empty",
+        linker_files = ":%s/linker" % name,
         objcopy_files = ":empty",
         strip_files = ":empty",
         supports_param_files = 0,

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -191,6 +191,11 @@ def _bin_has_native_dep_and_alwayslink_test_impl(ctx, use_cc_linker):
     toolchain = _get_toolchain(ctx)
     link_args = _extract_linker_args(action.argv)
     bin_dir = get_bin_dir_from_action(action)
+    linker_args = [arg for arg in action.argv if arg.startswith("--codegen=linker=")]
+
+    asserts.equals(env, 1, len(linker_args))
+    if bin_dir == "bazel-out/cfg/bin" and linker_args[0].startswith("--codegen=linker=bazel-out/"):
+        assert_argv_contains_prefix(env, action, "--codegen=linker={}/".format(bin_dir))
 
     # Validate bin_dir structure (ignoring ST-{hash} suffix from config transitions)
     _assert_bin_dir_structure(env, ctx, bin_dir, toolchain)


### PR DESCRIPTION
Support for --experimental_output_paths=strip added in 175bf94bdd
rewrites File-backed action arguments, but rustc still receives its
selected linker as a string. Generated Rust linkers and C/C++ linker
wrappers therefore retain their original configuration-specific
bazel-out paths and cannot be found inside mapped execution sandboxes.

Pass the selected Rust linker as its File and recover generated C/C++
linker Files from the C toolchain before constructing --codegen=linker.
Keep get_linker_and_args string-valued for Cargo build scripts. Extend
the existing analysis fixtures to cover both generated linker sources
with mapped and unmapped output paths.

Assisted-by: Codex