### PR TITLE
Include link_deps in Rust runfiles

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2074,6 +2074,7 @@ def rustc_compile_action(
     for runfiles_attr in (
         getattr(ctx.attr, "srcs", []),
         getattr(ctx.attr, "deps", []),
+        getattr(ctx.attr, "link_deps", []),
         getattr(ctx.attr, "data", []),
         [crate_attr] if crate_attr else [],
     ):
@@ -2084,7 +2085,7 @@ def rustc_compile_action(
     if crate_info.type in ["bin", "cdylib", "staticlib"]:
         dynamic_libraries = ctx.runfiles(files = [
             library_to_link.dynamic_library
-            for dep in getattr(ctx.attr, "deps", [])
+            for dep in getattr(ctx.attr, "deps", []) + getattr(ctx.attr, "link_deps", [])
             if CcInfo in dep
             for linker_input in dep[CcInfo].linking_context.linker_inputs.to_list()
             for library_to_link in linker_input.libraries


### PR DESCRIPTION
## Summary

- merge default runfiles from `link_deps` into Rust target runfiles
- include dynamic libraries supplied through `link_deps` alongside those from `deps`

## Why

`link_deps` participates in native linking, but its runfiles and dynamic libraries were omitted when `rustc_compile_action` assembled runtime files. Binaries and library targets that link native dependencies through `link_deps` could therefore be built successfully while missing required runtime artifacts.

## Impact

Rust binaries, `cdylib`s, and `staticlib`s now carry the runtime files needed by dependencies declared through `link_deps`.

## Validation

- `bazel test //test/unit/link_deps:all`
- `git diff --check`
