### PR TITLE
feat(mdbook): allow default configuration

### DIFF
--- a/extensions/mdbook/private/mdbook.bzl
+++ b/extensions/mdbook/private/mdbook.bzl
@@ -86,8 +86,8 @@ mdbook = rule(
     attrs = {
         "book": attr.label(
             doc = (
-                "The optional `book.toml` file. An empty default configuration is "
-                + "used when omitted."
+                "The optional `book.toml` file. An empty default configuration is " +
+                "used when omitted."
             ),
             allow_single_file = ["book.toml"],
         ),

--- a/extensions/mdbook/private/mdbook.bzl
+++ b/extensions/mdbook/private/mdbook.bzl
@@ -4,6 +4,7 @@ MdBookInfo = provider(
     doc = "Information about a `mdbook` target.",
     fields = {
         "config": "File: The `book.toml` file.",
+        "config_dest": "String: The path of the configuration file in the staged book.",
         "plugins": "Depset[File]: TODO",
         "srcs": "Depset[File]: TODO",
     },
@@ -24,6 +25,7 @@ def _mdbook_impl(ctx):
     output = ctx.actions.declare_directory(ctx.label.name)
 
     book = ctx.file.book
+    config_dest = "{}/{}".format(ctx.label.package, book.basename) if book != None else "{}/{}.book.toml".format(ctx.label.package, ctx.label.name)
     if book == None:
         book = ctx.actions.declare_file("{}.book.toml".format(ctx.label.name))
         ctx.actions.write(
@@ -53,7 +55,7 @@ def _mdbook_impl(ctx):
     args.add(output.path)
     args.add(toolchain.mdbook)
     args.add("build")
-    args.add("${{pwd}}/{}".format(book.dirname))
+    args.add("${{pwd}}/{}".format(ctx.label.package))
 
     ctx.actions.run(
         mnemonic = "MdBookBuild",
@@ -73,6 +75,7 @@ def _mdbook_impl(ctx):
         MdBookInfo(
             srcs = depset(ctx.files.srcs),
             config = book,
+            config_dest = config_dest,
             plugins = depset(ctx.files.plugins),
         ),
     ]
@@ -84,7 +87,7 @@ mdbook = rule(
         "book": attr.label(
             doc = (
                 "The optional `book.toml` file. An empty default configuration is "
-                "used when omitted."
+                + "used when omitted."
             ),
             allow_single_file = ["book.toml"],
         ),
@@ -131,12 +134,13 @@ def _mdbook_server_impl(ctx):
     workspace_name = ctx.workspace_name
 
     args.add("--mdbook={}".format(_rlocationpath(toolchain.mdbook, workspace_name)))
-    args.add("--config={}".format(_src_dest_path(book_info.config)))
+    args.add("--config={}".format(book_info.config_dest))
     args.add("--hostname={}".format(ctx.attr.hostname))
     args.add("--port={}".format(ctx.attr.port))
 
     def _src_map(file):
-        return "--src={}={}".format(_rlocationpath(file, workspace_name), _src_dest_path(file))
+        dest = book_info.config_dest if file == book_info.config else _src_dest_path(file)
+        return "--src={}={}".format(_rlocationpath(file, workspace_name), dest)
 
     # The set of files that must be staged into the workdir for `mdbook serve` to
     # see a consistent source tree. `book.toml` is included so that referencing it

--- a/extensions/mdbook/private/mdbook.bzl
+++ b/extensions/mdbook/private/mdbook.bzl
@@ -23,6 +23,14 @@ def _map_inputs(file):
 def _mdbook_impl(ctx):
     output = ctx.actions.declare_directory(ctx.label.name)
 
+    book = ctx.file.book
+    if book == None:
+        book = ctx.actions.declare_file("{}.book.toml".format(ctx.label.name))
+        ctx.actions.write(
+            output = book,
+            content = "",
+        )
+
     toolchain = ctx.toolchains["@rules_rust_mdbook//:toolchain_type"]
 
     plugin_paths = depset([
@@ -33,7 +41,7 @@ def _mdbook_impl(ctx):
     path_sep = ";" if is_windows else ":"
     plugin_path = path_sep.join(plugin_paths.to_list())
 
-    inputs = depset([ctx.file.book] + ctx.files.srcs)
+    inputs = depset([book] + ctx.files.srcs)
 
     inputs_map_args = ctx.actions.args()
     inputs_map_args.use_param_file("%s", use_always = True)
@@ -45,7 +53,7 @@ def _mdbook_impl(ctx):
     args.add(output.path)
     args.add(toolchain.mdbook)
     args.add("build")
-    args.add("${{pwd}}/{}".format(ctx.file.book.dirname))
+    args.add("${{pwd}}/{}".format(book.dirname))
 
     ctx.actions.run(
         mnemonic = "MdBookBuild",
@@ -64,7 +72,7 @@ def _mdbook_impl(ctx):
         ),
         MdBookInfo(
             srcs = depset(ctx.files.srcs),
-            config = ctx.file.book,
+            config = book,
             plugins = depset(ctx.files.plugins),
         ),
     ]
@@ -74,9 +82,11 @@ mdbook = rule(
     doc = "Rules to create book from markdown files using `mdBook`.",
     attrs = {
         "book": attr.label(
-            doc = "The `book.toml` file.",
+            doc = (
+                "The optional `book.toml` file. An empty default configuration is "
+                "used when omitted."
+            ),
             allow_single_file = ["book.toml"],
-            mandatory = True,
         ),
         "plugins": attr.label_list(
             doc = (

--- a/extensions/mdbook/test/default_config/BUILD.bazel
+++ b/extensions/mdbook/test/default_config/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//:defs.bzl", "mdbook")
+
+mdbook(
+    name = "default_config",
+    srcs = glob(["src/**/*.md"]),
+)
+
+build_test(
+    name = "default_config_test",
+    targets = [":default_config"],
+)

--- a/extensions/mdbook/test/default_config/src/SUMMARY.md
+++ b/extensions/mdbook/test/default_config/src/SUMMARY.md
@@ -1,0 +1,3 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)

--- a/extensions/mdbook/test/default_config/src/chapter_1.md
+++ b/extensions/mdbook/test/default_config/src/chapter_1.md
@@ -1,0 +1,3 @@
+# Chapter 1
+
+This book uses mdBook's default configuration.


### PR DESCRIPTION
## Summary

- make the `book` attribute optional for the `mdbook` rule
- generate an empty `book.toml` so mdBook uses its documented default configuration
- add a build test covering a book with only `src/SUMMARY.md` and chapter sources

This addresses #4194. The issue discussion asked for a PR that demonstrates mdBook can run without a user-provided `book.toml`; an empty configuration parses to mdBook's defaults, including `src` as the source directory. I kept the generated file in the package staging tree so the existing input mapping and `mdbook_server` provider continue to use the same config path. Let me know what you think.

## Validation

- `git diff --check` passed
- inspected mdBook 0.4.44 configuration defaults: an empty TOML file loads `src` as the source directory
- Bazel execution was not available in this Windows environment, so the new build target is left for the repository CI matrix