### PR TITLE
feat(rust_analyzer): treat crates from locally-overridden modules as workspace members

### DIFF
--- a/tools/rust_analyzer/cache.rs
+++ b/tools/rust_analyzer/cache.rs
@@ -43,7 +43,7 @@ const CACHE_DIR_REL_PREFIX: &str = ".rules_rust_analyzer";
 /// unchanged workspace would keep serving JSON assembled by an older
 /// version of the assembler. See the explanatory comment on
 /// `compute_key` for the incident that motivated this.
-const CACHE_SCHEMA_VERSION: u32 = 1;
+const CACHE_SCHEMA_VERSION: u32 = 2;
 
 /// Compute the cache key for an assembled rust-project.json from the raw
 /// spec contents plus every auxiliary input the assembler bakes into its
@@ -60,6 +60,7 @@ pub fn compute_key(
     workspace: &Utf8Path,
     execution_root: &Utf8Path,
     launcher_dir: &str,
+    local_override_roots: &[Utf8PathBuf],
 ) -> String {
     let mut hasher = DefaultHasher::new();
     CACHE_SCHEMA_VERSION.hash(&mut hasher);
@@ -67,6 +68,13 @@ pub fn compute_key(
     workspace.as_str().hash(&mut hasher);
     execution_root.as_str().hash(&mut hasher);
     toolchain_info.hash(&mut hasher);
+    // Adding or removing a module override changes workspace membership in
+    // the assembled JSON without necessarily changing any crate spec (the
+    // canonical repo name — and thus every path — can stay identical), so
+    // the override set must invalidate the cache on its own.
+    for root in local_override_roots {
+        root.as_str().hash(&mut hasher);
+    }
     // Hashed because `flycheck_launcher_path` in `rust_project.rs` reads
     // `$RULES_RUST_RA_LAUNCHER_DIR` to bake an absolute path into the
     // assembled JSON. If we left this out, switching editors
@@ -171,8 +179,8 @@ mod tests {
                 String::from("{\"id\":\"b\"}"),
             ),
         ];
-        let k1 = compute_key(&specs, toolchain, bazel, ws, er, "");
-        let k2 = compute_key(&specs, toolchain, bazel, ws, er, "");
+        let k1 = compute_key(&specs, toolchain, bazel, ws, er, "", &[]);
+        let k2 = compute_key(&specs, toolchain, bazel, ws, er, "", &[]);
         assert_eq!(k1, k2);
     }
 
@@ -185,8 +193,8 @@ mod tests {
         let base = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         let mutated = vec![(Utf8PathBuf::from("a.json"), "b".to_string())];
         assert_ne!(
-            compute_key(&base, toolchain, bazel, ws, er, ""),
-            compute_key(&mutated, toolchain, bazel, ws, er, "")
+            compute_key(&base, toolchain, bazel, ws, er, "", &[]),
+            compute_key(&mutated, toolchain, bazel, ws, er, "", &[])
         );
     }
 
@@ -197,8 +205,8 @@ mod tests {
         let er = Utf8Path::new("/er");
         let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         assert_ne!(
-            compute_key(&specs, "{\"sysroot\":\"a\"}", bazel, ws, er, ""),
-            compute_key(&specs, "{\"sysroot\":\"b\"}", bazel, ws, er, ""),
+            compute_key(&specs, "{\"sysroot\":\"a\"}", bazel, ws, er, "", &[]),
+            compute_key(&specs, "{\"sysroot\":\"b\"}", bazel, ws, er, "", &[]),
         );
     }
 
@@ -208,8 +216,8 @@ mod tests {
         let er = Utf8Path::new("/er");
         let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         assert_ne!(
-            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws1"), er, ""),
-            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws2"), er, ""),
+            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws1"), er, "", &[]),
+            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws2"), er, "", &[]),
         );
     }
 
@@ -231,6 +239,7 @@ mod tests {
                 ws,
                 er,
                 "/ws/.vscode/.rules_rust_analyzer",
+                &[],
             ),
             compute_key(
                 &specs,
@@ -239,6 +248,30 @@ mod tests {
                 ws,
                 er,
                 "/ws/.helix/.rules_rust_analyzer",
+                &[],
+            ),
+        );
+    }
+
+    #[test]
+    fn compute_key_changes_with_override_roots() {
+        // Adding/removing a module override can leave every crate spec
+        // byte-identical (the canonical repo name doesn't change), so the
+        // override set must invalidate the cache by itself.
+        let bazel = Utf8Path::new("/usr/bin/bazel");
+        let ws = Utf8Path::new("/ws");
+        let er = Utf8Path::new("/er");
+        let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
+        assert_ne!(
+            compute_key(&specs, "{}", bazel, ws, er, "", &[]),
+            compute_key(
+                &specs,
+                "{}",
+                bazel,
+                ws,
+                er,
+                "",
+                &[Utf8PathBuf::from("/ob/external/mypkg+")],
             ),
         );
     }

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -1,6 +1,7 @@
 mod aquery;
 pub mod bep;
 mod cache;
+mod overrides;
 mod rust_project;
 pub mod user_config;
 
@@ -203,6 +204,21 @@ pub fn generate_rust_project(
 
     let spec_contents = read_specs(&spec_paths)?;
 
+    // Crates from locally-overridden modules (`local_path_override`,
+    // `--override_module`) are first-party code; `assemble_rust_project`
+    // marks them as workspace members. Detected before the cache check and
+    // hashed into the key: flipping an override does not necessarily change
+    // any crate spec content, so it must invalidate the cache on its own.
+    let local_override_roots =
+        overrides::local_override_repo_roots(bazel, workspace, output_base, bazel_startup_options)
+            .unwrap_or_else(|e| {
+                log::warn!(
+                    "detecting module overrides failed ({e:#}); crates from \
+             overridden modules will not be marked as workspace members"
+                );
+                Vec::new()
+            });
+
     let launcher_dir = std::env::var(cache::LAUNCHER_DIR_ENV_VAR).unwrap_or_default();
     let cache_key = cache::compute_key(
         &spec_contents,
@@ -211,6 +227,7 @@ pub fn generate_rust_project(
         workspace,
         execution_root,
         &launcher_dir,
+        &local_override_roots,
     );
     if let Some(bytes) = cache::get(workspace, &cache_key)? {
         match serde_json::from_slice::<RustProject>(&bytes) {
@@ -251,8 +268,13 @@ pub fn generate_rust_project(
         );
     }
 
-    let project =
-        rust_project::assemble_rust_project(bazel, workspace, toolchain_info, &crate_specs)?;
+    let project = rust_project::assemble_rust_project(
+        bazel,
+        workspace,
+        toolchain_info,
+        &crate_specs,
+        &local_override_roots,
+    )?;
 
     // Log warnings AND persist to disk — progress events scroll off
     // the status bar before anyone reads them.

--- a/tools/rust_analyzer/overrides.rs
+++ b/tools/rust_analyzer/overrides.rs
@@ -1,0 +1,269 @@
+//! Detection of Bazel modules with local (non-registry) overrides.
+//!
+//! A module declared with `local_path_override` or `--override_module` has
+//! its sources in a checkout the user edits directly, but Bazel surfaces it
+//! through a symlink at `{output_base}/external/<repo>/`. The rust-analyzer
+//! aspect classifies every crate under `external/` as a non-member, so
+//! rust-analyzer shows no diagnostics for these first-party crates. This
+//! module asks Bazel which external repos are really local overrides so
+//! `rust_project.rs` can treat their crates as workspace members.
+//! See <https://github.com/bazelbuild/rules_rust/issues/4213>.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::Context;
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::Deserialize;
+
+use crate::bazel_command;
+
+/// A module node in `bazel mod graph --output json`.
+#[derive(Debug, Deserialize)]
+struct ModGraphNode {
+    /// `<name>@<version>`; modules with a non-registry override render as
+    /// `<name>@_` (the `version` field still carries the declared version,
+    /// so the key is the only reliable override marker).
+    #[serde(default)]
+    key: String,
+    #[serde(default)]
+    name: String,
+    /// The repo name the parent module uses for this dependency.
+    #[serde(rename = "apparentName", default)]
+    apparent_name: String,
+    #[serde(default)]
+    dependencies: Vec<ModGraphNode>,
+    #[serde(rename = "indirectDependencies", default)]
+    indirect_dependencies: Vec<ModGraphNode>,
+}
+
+/// External repository roots (under `{output_base}/external/`) of modules
+/// with local overrides — non-registry overrides whose repo directory is a
+/// symlink back into a real checkout.
+///
+/// Best-effort: when the `bazel mod` command itself fails (WORKSPACE mode,
+/// pre-bzlmod Bazel), this logs and returns an empty list so gen_rust_project
+/// behaves exactly as before. Unparseable output is an error — that means
+/// the format changed and this code needs updating.
+pub fn local_override_repo_roots(
+    bazel: &Utf8Path,
+    workspace: &Utf8Path,
+    output_base: &Utf8Path,
+    bazel_startup_options: &[String],
+) -> anyhow::Result<Vec<Utf8PathBuf>> {
+    let graph_json = match run_bazel_mod(
+        bazel,
+        workspace,
+        output_base,
+        bazel_startup_options,
+        &["graph", "--output", "json"],
+    ) {
+        Ok(stdout) => stdout,
+        Err(e) => {
+            log::debug!("`bazel mod graph` unavailable ({e:#}); assuming no module overrides");
+            return Ok(Vec::new());
+        }
+    };
+
+    let overridden = overridden_modules(&graph_json)?;
+    if overridden.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Resolve module names to canonical repo names through the root module's
+    // repo mapping — authoritative for every repo the root can see, across
+    // the canonical-name schemes of different Bazel versions.
+    let mapping_json = run_bazel_mod(
+        bazel,
+        workspace,
+        output_base,
+        bazel_startup_options,
+        &["dump_repo_mapping", ""],
+    )
+    .context("`bazel mod dump_repo_mapping` failed after `bazel mod graph` succeeded")?;
+    let mapping: BTreeMap<String, String> =
+        serde_json::from_str(&mapping_json).context("parsing `bazel mod dump_repo_mapping`")?;
+
+    let external = output_base.join("external");
+    let roots = overridden
+        .iter()
+        .map(|module| {
+            let canonical = match mapping.get(&module.apparent_name) {
+                Some(canonical) => canonical.clone(),
+                // Overridden but not visible from the root module (an
+                // override of a transitively-used module). Fall back to
+                // Bazel's documented canonical name for modules, `<name>+`.
+                None => format!("{}+", module.name),
+            };
+            external.join(canonical)
+        })
+        // Keep only repos that are symlinks: that is what distinguishes a
+        // *local* override (`local_path_override`, `--override_module`) from
+        // a fetched non-registry override (`git_override`,
+        // `archive_override`), whose sources are not editable checkouts.
+        .filter(|root| {
+            root.symlink_metadata()
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+        })
+        .collect();
+
+    Ok(roots)
+}
+
+/// An overridden module: its declared name and the name the root module
+/// knows it by.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OverriddenModule {
+    name: String,
+    apparent_name: String,
+}
+
+/// Walk the module graph and collect every module whose key carries the
+/// non-registry-override marker (`<name>@_`).
+fn overridden_modules(graph_json: &str) -> anyhow::Result<BTreeSet<OverriddenModule>> {
+    let root: ModGraphNode =
+        serde_json::from_str(graph_json).context("parsing `bazel mod graph --output json`")?;
+
+    let mut found = BTreeSet::new();
+    let mut stack = vec![&root];
+    while let Some(node) = stack.pop() {
+        if node.key.ends_with("@_") {
+            found.insert(OverriddenModule {
+                name: node.name.clone(),
+                apparent_name: node.apparent_name.clone(),
+            });
+        }
+        stack.extend(&node.dependencies);
+        stack.extend(&node.indirect_dependencies);
+    }
+    Ok(found)
+}
+
+fn run_bazel_mod(
+    bazel: &Utf8Path,
+    workspace: &Utf8Path,
+    output_base: &Utf8Path,
+    bazel_startup_options: &[String],
+    mod_args: &[&str],
+) -> anyhow::Result<String> {
+    let output = bazel_command(bazel, Some(workspace), Some(output_base))
+        .args(bazel_startup_options)
+        .arg("mod")
+        .args(mod_args)
+        .output()
+        .with_context(|| format!("spawning `bazel mod {}`", mod_args.join(" ")))?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "`bazel mod {}` failed ({}):\n{}",
+            mod_args.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    String::from_utf8(output.stdout).context("`bazel mod` output is not UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Trimmed-down real output of `bazel mod graph --output json` from a
+    /// workspace with one `local_path_override` module (`mypkg@_`) among
+    /// regular registry dependencies.
+    const GRAPH_JSON: &str = r#"{
+        "key": "<root>",
+        "name": "myworkspace",
+        "version": "1.0.0",
+        "apparentName": "myworkspace",
+        "dependencies": [
+            {
+                "key": "rules_rust@0.73.0",
+                "name": "rules_rust",
+                "version": "0.73.0",
+                "apparentName": "rules_rust",
+                "dependencies": [],
+                "indirectDependencies": [],
+                "cycles": []
+            },
+            {
+                "key": "mypkg@_",
+                "name": "mypkg",
+                "version": "0.1.0",
+                "apparentName": "mypkg",
+                "dependencies": [],
+                "indirectDependencies": [],
+                "cycles": []
+            }
+        ],
+        "indirectDependencies": [],
+        "cycles": []
+    }"#;
+
+    #[test]
+    fn overridden_modules_found_by_key_marker() {
+        let found = overridden_modules(GRAPH_JSON).unwrap();
+        // `mypkg` is overridden (key `mypkg@_`) even though its `version`
+        // field carries a declared version; `rules_rust` is not.
+        assert_eq!(found.len(), 1);
+        let module = found.first().unwrap();
+        assert_eq!(module.name, "mypkg");
+        assert_eq!(module.apparent_name, "mypkg");
+    }
+
+    #[test]
+    fn no_overrides_yields_empty_set() {
+        let graph = r#"{
+            "key": "<root>",
+            "name": "myworkspace",
+            "version": "1.0.0",
+            "apparentName": "myworkspace",
+            "dependencies": [
+                {
+                    "key": "rules_rust@0.73.0",
+                    "name": "rules_rust",
+                    "version": "0.73.0",
+                    "apparentName": "rules_rust"
+                }
+            ]
+        }"#;
+        assert!(overridden_modules(graph).unwrap().is_empty());
+    }
+
+    #[test]
+    fn nested_overrides_are_collected() {
+        // An override of a module the root only reaches transitively still
+        // shows the `@_` marker on the nested node.
+        let graph = r#"{
+            "key": "<root>",
+            "name": "myworkspace",
+            "version": "1.0.0",
+            "apparentName": "myworkspace",
+            "dependencies": [
+                {
+                    "key": "some_dep@1.0.0",
+                    "name": "some_dep",
+                    "version": "1.0.0",
+                    "apparentName": "some_dep",
+                    "dependencies": [
+                        {
+                            "key": "transitive_pkg@_",
+                            "name": "transitive_pkg",
+                            "version": "2.0.0",
+                            "apparentName": "transitive_pkg"
+                        }
+                    ]
+                }
+            ]
+        }"#;
+        let found = overridden_modules(graph).unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found.first().unwrap().name, "transitive_pkg");
+    }
+
+    #[test]
+    fn malformed_graph_is_an_error() {
+        assert!(overridden_modules("not json").is_err());
+    }
+}

--- a/tools/rust_analyzer/rust_project.rs
+++ b/tools/rust_analyzer/rust_project.rs
@@ -475,6 +475,7 @@ pub fn assemble_rust_project(
     workspace: &Utf8Path,
     toolchain_info: ToolchainInfo,
     crate_specs: &BTreeSet<CrateSpec>,
+    local_override_roots: &[Utf8PathBuf],
 ) -> anyhow::Result<RustProject> {
     let emit_test_mod = supports_test_mod(&toolchain_info.version);
 
@@ -607,16 +608,46 @@ pub fn assemble_rust_project(
             })
             .collect();
 
+        // Crates from locally-overridden modules (`local_path_override`,
+        // `--override_module`) sit under `{output_base}/external/` and are
+        // therefore marked non-members by the aspect, but their repo is a
+        // symlink into a checkout the user edits directly. Treat them as
+        // workspace members so rust-analyzer surfaces diagnostics, and
+        // canonicalize their paths — editors put the *real* path in file
+        // URIs, and rust-analyzer's file→crate mapping compares paths
+        // textually. `root_module` and `source.include_dirs` must be
+        // rewritten in lockstep: canonicalizing only one of them breaks the
+        // mapping and every item from the crate resolves as an unresolved
+        // import. Generated sources of these modules live under
+        // `bazel-out/`, never under an override root, so they keep their
+        // execution-root paths.
+        let is_local_override = local_override_roots
+            .iter()
+            .any(|root| Utf8Path::new(&c.root_module).starts_with(root));
+
+        let root_module = if is_local_override {
+            canonicalize_lossy(&c.root_module)
+        } else {
+            c.root_module.clone()
+        };
+
         project.crates.push(Crate {
             display_name: Some(c.display_name.clone()),
-            root_module: c.root_module.clone(),
+            root_module,
             edition: c.edition.clone(),
             deps,
-            is_workspace_member: Some(c.is_workspace_member),
+            is_workspace_member: Some(c.is_workspace_member || is_local_override),
             source: match &c.source {
                 Some(s) => Source {
                     exclude_dirs: s.exclude_dirs.clone(),
-                    include_dirs: s.include_dirs.clone(),
+                    include_dirs: if is_local_override {
+                        s.include_dirs
+                            .iter()
+                            .map(|d| canonicalize_lossy(d))
+                            .collect()
+                    } else {
+                        s.include_dirs.clone()
+                    },
                 },
                 None => Source::default(),
             },
@@ -638,6 +669,16 @@ pub fn assemble_rust_project(
     }
 
     Ok(project)
+}
+
+/// Resolve symlinks so a path through `{output_base}/external/<repo>` maps
+/// to the real checkout it points at. Falls back to the input unchanged when
+/// resolution fails (path doesn't exist, permission error) — a dangling
+/// original is no worse than a dangling fallback.
+fn canonicalize_lossy(path: &str) -> String {
+    std::fs::canonicalize(path)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.to_owned())
 }
 
 #[cfg(test)]
@@ -686,6 +727,7 @@ mod tests {
                 is_test: false,
                 build: None,
             }]),
+            &[],
         )
         .expect("expect success");
 
@@ -760,6 +802,7 @@ mod tests {
                     build: None,
                 },
             ]),
+            &[],
         )
         .expect("expect success");
 
@@ -811,6 +854,7 @@ mod tests {
                 version: String::new(),
             },
             &BTreeSet::from([spec("ID-a", &["ID-b"]), spec("ID-b", &["ID-a"])]),
+            &[],
         )
         .expect("cycle must not fail assembly");
 
@@ -844,6 +888,7 @@ mod tests {
                 version: String::new(),
             },
             &BTreeSet::from([spec("ID-a", &["ID-nonexistent"])]),
+            &[],
         )
         .expect("missing dep must not fail assembly");
 
@@ -867,6 +912,7 @@ mod tests {
                 version: String::new(),
             },
             &BTreeSet::from([spec("ID-a", &[])]),
+            &[],
         )
         .expect("expect success");
 
@@ -879,6 +925,93 @@ mod tests {
             flycheck.args,
             vec!["{label}".to_owned(), "{saved_file}".to_owned()],
         );
+    }
+
+    /// A crate whose root_module falls under a local-override root becomes a
+    /// workspace member; crates outside the roots keep the aspect's verdict.
+    #[test]
+    fn local_override_crate_becomes_workspace_member() {
+        let mut override_crate = spec("ID-mypkg", &[]);
+        override_crate.is_workspace_member = false;
+        override_crate.root_module = "/output_base/external/mypkg+/src/lib.rs".into();
+        let mut registry_crate = spec("ID-anyhow", &[]);
+        registry_crate.is_workspace_member = false;
+        registry_crate.root_module =
+            "/output_base/external/rules_rust+crate+anyhow-1.0.0/src/lib.rs".into();
+
+        let project = assemble_rust_project(
+            Utf8Path::new("bazel"),
+            Utf8Path::new("workspace"),
+            ToolchainInfo {
+                sysroot: "sysroot".to_owned().into(),
+                sysroot_src: "sysroot_src".to_owned().into(),
+                version: String::new(),
+            },
+            &BTreeSet::from([override_crate, registry_crate]),
+            &[Utf8PathBuf::from("/output_base/external/mypkg+")],
+        )
+        .expect("expect success");
+
+        let member = |name: &str| {
+            project
+                .crates
+                .iter()
+                .find(|c| c.display_name.as_deref() == Some(name))
+                .unwrap()
+                .is_workspace_member
+        };
+        assert_eq!(member("mypkg"), Some(true));
+        assert_eq!(member("anyhow"), Some(false));
+        // The paths don't exist on disk, so canonicalization falls back to
+        // the input unchanged rather than dropping the crate.
+        assert!(project
+            .crates
+            .iter()
+            .any(|c| c.root_module == "/output_base/external/mypkg+/src/lib.rs"));
+    }
+
+    /// With a real symlinked repo (what `local_path_override` produces),
+    /// `root_module` is rewritten to the checkout path the editor reports.
+    #[cfg(unix)]
+    #[test]
+    fn local_override_paths_resolve_through_symlink() {
+        let temp = std::env::temp_dir().join(format!(
+            "rules_rust_ra_override_test_{}",
+            std::process::id()
+        ));
+        let checkout = temp.join("checkout/mypkg");
+        let external = temp.join("output_base/external");
+        std::fs::create_dir_all(checkout.join("src")).unwrap();
+        std::fs::create_dir_all(&external).unwrap();
+        std::fs::write(checkout.join("src/lib.rs"), "").unwrap();
+        let repo = external.join("mypkg+");
+        std::os::unix::fs::symlink(&checkout, &repo).unwrap();
+
+        let mut override_crate = spec("ID-mypkg", &[]);
+        override_crate.is_workspace_member = false;
+        override_crate.root_module = format!("{}/src/lib.rs", repo.display());
+
+        let project = assemble_rust_project(
+            Utf8Path::new("bazel"),
+            Utf8Path::new("workspace"),
+            ToolchainInfo {
+                sysroot: "sysroot".to_owned().into(),
+                sysroot_src: "sysroot_src".to_owned().into(),
+                version: String::new(),
+            },
+            &BTreeSet::from([override_crate]),
+            &[Utf8PathBuf::from_path_buf(repo.clone()).unwrap()],
+        )
+        .expect("expect success");
+
+        // Compare against a canonicalized expectation — the temp dir itself
+        // may sit behind a symlink (e.g. /tmp on macOS).
+        let expected = std::fs::canonicalize(checkout.join("src/lib.rs")).unwrap();
+        let c = &project.crates[0];
+        assert_eq!(c.root_module, expected.to_string_lossy());
+        assert_eq!(c.is_workspace_member, Some(true));
+
+        std::fs::remove_dir_all(&temp).unwrap();
     }
 
     // --- diagnose() suite ---


### PR DESCRIPTION
Fixes #4213 (the Bug 2 follow-up from #4057). Opening as a **draft** — this is a concrete proposal for the direction discussion in the issue; happy to rework or split it based on feedback.

## Problem

Crates from modules declared with `local_path_override` (or `--override_module`) are first-party code the user edits daily, but they sit under `{output_base}/external/<repo>/`, so the aspect marks them `is_workspace_member: false` and rust-analyzer shows no diagnostics for them.

## Approach

This implements the "combined" option from #4213: ask Bazel which repos are really local overrides, and only touch crates under those repos.

**Detection** (`tools/rust_analyzer/overrides.rs`, new):
- `bazel mod graph --output json` — modules with a non-registry override render with the version placeholder `_` in their `key` (e.g. `mypkg@_`; the `version` field still carries the declared version, so the key is the only reliable marker). The whole graph is walked, so overrides of transitively-used modules are found too.
- `bazel mod dump_repo_mapping ''` — resolves module names to canonical repo names authoritatively, instead of hard-coding a canonical-name scheme that has changed across Bazel versions. (Fallback `<name>+` for overridden modules not visible from the root module.)
- Only repos whose directory is a **symlink** count as local — that's what path-based overrides produce, and it excludes `git_override`/`archive_override` fetches, which are not editable checkouts.
- In WORKSPACE mode `bazel mod` fails; detection logs at debug level and degrades to today's behavior.

**Assembly** (`rust_project.rs`): crates whose `root_module` falls under a detected root are marked workspace members, and their `root_module` + `source.include_dirs` are canonicalized **in lockstep** — editors put the real path in file URIs and rust-analyzer's file→crate mapping compares paths textually; canonicalizing only one of the two breaks the mapping and every item from the crate resolves as an unresolved import (we learned this in production). Generated sources live under `bazel-out/`, never under an override root, so they are untouched.

**Cache** (`cache.rs`): the override set is hashed into the merge cache key and the schema version is bumped. Flipping an override does not necessarily change any crate spec content (the canonical repo name — and thus every path in the specs — can stay identical), so it must invalidate the cache on its own.

## Cost

Two extra `bazel mod` invocations per project generation (no analysis, answered by the running server); the second one is skipped when no overrides exist.

## Known limitation

The aspect only emits `build` info (labels for runnables/flycheck) for crates it considers local, so override-module crates gain diagnostics but not codelens runnables. That would need an aspect-side change and feels like a separate discussion.

## Testing

- Unit tests for the graph parsing (override marker, nested overrides, no-override, malformed input), membership marking, cache-key sensitivity, and a unix test with a real symlinked repo verifying path canonicalization.
- `bazel test //tools/rust_analyzer:gen_rust_project_lib_test` (51 tests) and `//tools/rust_analyzer:gen_rust_project_clippy` pass; rustfmt clean.
- The `bazel mod` output shapes were verified against a real Bazel 9 bzlmod workspace with five `local_path_override` modules; we run the equivalent of this fix as a patch in our monorepo, where it restores diagnostics for all override-module crates.

Per the AI tools policy: prepared with LLM assistance (see `Assisted-by` commit trailer), reviewed and tested by me.