### PR TITLE
pyo3: make //toolchains:pyo3 publicly visible

### DIFF
--- a/extensions/pyo3/toolchains/BUILD.bazel
+++ b/extensions/pyo3/toolchains/BUILD.bazel
@@ -3,6 +3,7 @@ load("//:defs.bzl", "pyo3_toolchain", "rust_pyo3_toolchain")
 
 rust_library_group(
     name = "pyo3",
+    visibility = ["//visibility:public"],
     deps = [
         "@rpyo3c//:pyo3",
     ],


### PR DESCRIPTION
`//toolchains:pyo3` (the `rust_library_group` wrapping `@rpyo3c//:pyo3`) is the natural dependency for plain `rust_library` crates that link against pyo3 outside of a `pyo3_extension` — e.g. a shared bridge library consumed by several extensions.

Today the target is package-private, so consumers have to either hard-code the bzlmod canonical repo label (`@@rules_rust_pyo3~~rust_ext~rpyo3c//:pyo3`) or `use_repo` the internal `rust_ext` extension from `//private:internal_extensions.bzl` — both couple downstream workspaces to implementation details (canonical-name mangling, internal extension paths) that change across Bazel releases.

This makes the existing target publicly visible so it can serve as the supported label, one line:

```python
rust_library_group(
    name = "pyo3",
    visibility = ["//visibility:public"],
    deps = ["@rpyo3c//:pyo3"],
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)