### PR TITLE
fix(rustdoc): link doc tests against the cc_toolchain's runtime libs

### DIFF
--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -144,6 +144,10 @@ def rustdoc_compile_action(
     # back to the crate root, which is always a `File` per the provider contract.
     rustdoc_crate_info = _rustdoc_crate_info(crate_info, output if output != None else crate_info.root)
 
+    # Runtime libs contributed by the cc_toolchain, tracked so `rust_doc_test`
+    # can strip their (separately configured) root from the runfiles paths.
+    static_runtime_libs = []
+
     # rustdoc does not understand linker flags like -lstatic that
     # `include_link_flags` generates. So we manually build flags that only apply
     # to rustdoc.
@@ -163,6 +167,33 @@ def rustdoc_compile_action(
                 if not (lib.static_library or lib.pic_static_library):
                     continue
                 arg = get_lib_name(get_preferred_artifact(lib, use_pic))
+                if not for_windows:
+                    arg = "-l" + arg
+                if type(rustdoc_flags) == "Args":
+                    rustdoc_flags.add("-Clink-arg=%s" % arg)
+                else:
+                    rustdoc_flags.append("-Clink-arg=%s" % arg)
+
+        # The cc_toolchain's runtime libs (libc++ / libunwind on any toolchain
+        # enabling `static_link_cpp_runtimes`) are NOT part of
+        # transitive_noncrates: Bazel injects them into C++ link actions, and
+        # rustdoc never runs one -- it drives the link itself.
+        # `add_native_link_flags` emits their `-Lnative=` search path
+        # unconditionally but gates the matching `-lstatic=` behind
+        # `include_link_flags`, which is False for rustdoc. Without the `-l`
+        # below the archives sit on the search path with nothing referencing
+        # them, and every doc test fails to link with undefined `_Unwind_*`.
+        #
+        # Mirrors the crate-type split in `collect_inputs`, so the libs named
+        # here are the ones that were added to the action inputs.
+        if cc_toolchain:
+            if crate_info.type in ["dylib", "cdylib"]:
+                runtime_libs = cc_toolchain.dynamic_runtime_lib(feature_configuration = feature_configuration)
+            else:
+                runtime_libs = cc_toolchain.static_runtime_lib(feature_configuration = feature_configuration)
+            for lib in runtime_libs.to_list():
+                static_runtime_libs.append(lib)
+                arg = get_lib_name(lib)
                 if not for_windows:
                     arg = "-l" + arg
                 if type(rustdoc_flags) == "Args":
@@ -214,6 +245,7 @@ def rustdoc_compile_action(
         arguments = args.all,
         supports_path_mapping = args.supports_path_mapping,
         tools = [toolchain.rust_doc],
+        static_runtime_libs = static_runtime_libs,
     )
 
 def _zip_action(ctx, input_dir, output_zip, crate_label):

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -89,6 +89,21 @@ def _construct_writer_arguments(ctx, test_runner, opt_test_params, action, crate
         if dep_cc_info:
             _collect_library_roots(roots, dep_cc_info.linking_context.linker_inputs)
 
+    # The cc_toolchain runtime libs (see rustdoc.bzl) are built in their own
+    # configuration, so their root differs from every crate root collected
+    # above. Without stripping it too, the `-Lnative=` search path rustc emits
+    # for them stays an execroot path that does not exist under runfiles, and
+    # the linker reports "unable to find library".
+    #
+    # Source files have an empty root, and they need no stripping: their
+    # `-Lnative=` path is already workspace-relative. Skip them -- an empty
+    # root would add `--strip_substring=/`, and the writer applies these as
+    # plain string replacements, so that would delete every `/` in every
+    # argument.
+    for lib in action.static_runtime_libs:
+        if lib.root.path:
+            roots.append(lib.root.path)
+
     writer_args.add_all(roots, format_each = "--strip_substring=%s/", uniquify = True)
 
     # Indicate that the rustdoc_test args are over.

--- a/test/unit/cc_toolchain_runtime_lib/cc_toolchain_runtime_lib_test.bzl
+++ b/test/unit/cc_toolchain_runtime_lib/cc_toolchain_runtime_lib_test.bzl
@@ -7,7 +7,7 @@ load("@rules_cc//cc:cc_toolchain_config_lib.bzl", "feature")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
-load("//rust:defs.bzl", "rust_shared_library", "rust_static_library")
+load("//rust:defs.bzl", "rust_doc_test", "rust_library", "rust_shared_library", "rust_static_library")
 
 def _test_cc_config_impl(ctx):
     config_info = cc_common.create_cc_toolchain_config_info(
@@ -81,6 +81,53 @@ inputs_analysis_test = analysistest.make(
     },
 )
 
+def _rustdoc_link_args_analysis_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+
+    actions = tut[DepActionsInfo].actions
+    action = None
+    for candidate in actions:
+        if candidate.mnemonic in ["RustdocTestWriter", "RustdocTestCompile"]:
+            action = candidate
+            break
+
+    asserts.true(
+        env,
+        action != None,
+        "error: no rustdoc test action found among: {}".format(
+            [candidate.mnemonic for candidate in actions],
+        ),
+    )
+
+    if action:
+        for expected in ctx.attr.expected_args:
+            asserts.true(
+                env,
+                expected in action.argv,
+                "error: expected '{}' in the rustdoc test link args: '{}'".format(
+                    expected,
+                    action.argv,
+                ),
+            )
+
+    return analysistest.end(env)
+
+rustdoc_link_args_analysis_test = analysistest.make(
+    impl = _rustdoc_link_args_analysis_test_impl,
+    doc = """An analysistest to examine the link args of a rust_doc_test target.
+
+    rustdoc drives the doc test link itself rather than running a Bazel C++
+    link action, so the cc_toolchain's runtime libs never arrive through
+    `static_link_cpp_runtimes` the way they do for a rust_library. They have to
+    be named explicitly on the rustdoc command line instead, or the doc test
+    fails to link against a toolchain that supplies its own unwinder.
+    """,
+    attrs = {
+        "expected_args": attr.string_list(),
+    },
+)
+
 def runtime_libs_test(name):
     """Produces test shared and static library targets that are set up to use a custom cc_toolchain with custom runtime libs.
 
@@ -149,4 +196,34 @@ def runtime_libs_test(name):
         name = "%s/static_library" % name,
         target_under_test = "%s/_static_library" % name,
         expected_inputs = ["dummy.a"],
+    )
+
+    # A doc test links like a binary, so it needs the static runtime lib named
+    # on the command line. `dummy.a` yields `-ldummy` via `get_lib_name`.
+    rust_library(
+        name = "%s/__doctest_library" % name,
+        edition = "2018",
+        srcs = ["lib.rs"],
+        tags = ["manual", "nobuild"],
+    )
+
+    rust_doc_test(
+        name = "%s/__doc_test" % name,
+        crate = ":%s/__doctest_library" % name,
+        tags = ["manual", "nobuild"],
+    )
+
+    with_extra_toolchain(
+        name = "%s/_doc_test" % name,
+        extra_toolchain = ":%s/test_cc_toolchain" % name,
+        target = "%s/__doc_test" % name,
+        tags = ["manual"],
+        # rust_doc_test is a test rule, so it is testonly.
+        testonly = True,
+    )
+
+    rustdoc_link_args_analysis_test(
+        name = "%s/doc_test" % name,
+        target_under_test = "%s/_doc_test" % name,
+        expected_args = ["-Clink-arg=-ldummy"],
     )

--- a/test/unit/cc_toolchain_runtime_lib/cc_toolchain_runtime_lib_test.bzl
+++ b/test/unit/cc_toolchain_runtime_lib/cc_toolchain_runtime_lib_test.bzl
@@ -101,15 +101,17 @@ def _rustdoc_link_args_analysis_test_impl(ctx):
     )
 
     if action:
-        for expected in ctx.attr.expected_args:
-            asserts.true(
-                env,
-                expected in action.argv,
-                "error: expected '{}' in the rustdoc test link args: '{}'".format(
-                    expected,
-                    action.argv,
-                ),
-            )
+        # Any one of the accepted spellings is enough: `rustdoc.bzl` omits the
+        # `-l` prefix when the target ABI is msvc, where link.exe takes bare
+        # library names.
+        asserts.true(
+            env,
+            any([expected in action.argv for expected in ctx.attr.expected_any_of]),
+            "error: expected one of {} in the rustdoc test link args: '{}'".format(
+                ctx.attr.expected_any_of,
+                action.argv,
+            ),
+        )
 
     return analysistest.end(env)
 
@@ -124,7 +126,7 @@ rustdoc_link_args_analysis_test = analysistest.make(
     fails to link against a toolchain that supplies its own unwinder.
     """,
     attrs = {
-        "expected_args": attr.string_list(),
+        "expected_any_of": attr.string_list(),
     },
 )
 
@@ -199,7 +201,8 @@ def runtime_libs_test(name):
     )
 
     # A doc test links like a binary, so it needs the static runtime lib named
-    # on the command line. `dummy.a` yields `-ldummy` via `get_lib_name`.
+    # on the command line. `dummy.a` yields `dummy` via `get_lib_name`, spelled
+    # `-ldummy` everywhere except msvc.
     rust_library(
         name = "%s/__doctest_library" % name,
         edition = "2018",
@@ -225,5 +228,9 @@ def runtime_libs_test(name):
     rustdoc_link_args_analysis_test(
         name = "%s/doc_test" % name,
         target_under_test = "%s/_doc_test" % name,
-        expected_args = ["-Clink-arg=-ldummy"],
+        expected_any_of = [
+            "-Clink-arg=-ldummy",
+            # msvc: link.exe takes bare library names, no `-l`.
+            "-Clink-arg=dummy",
+        ],
     )


### PR DESCRIPTION
`rust_doc_test` fails to link on any cc_toolchain that supplies its C++/unwind
runtime via `static_runtime_lib` (i.e. enables `static_link_cpp_runtimes`). 
This happens when cross compiling with the hermetic-LLVM e.g.:

```
ld.lld: error: undefined symbol: _Unwind_Resume
>>> referenced by alloc.rs:0 ... liballoc-*.rlib
... and the rest of the _Unwind_* family
```

`rust_library` / `rust_binary` / `rust_test` are fine. Only doc tests fail. 

## Evidence

The first commit adds only a test to reproduce the issue by extending the
fixture from #3741 (which already declares a cc_toolchain with
`static_runtime_lib = ":dummy.a"`); the second commit adds the fix:

| commit | `//test/unit/cc_toolchain_runtime_lib:runtime_libs_test/doc_test` |
|---|---|
| `test(rustdoc): reproduce ...` | **FAILED** |
| `fix(rustdoc): link doc tests ...` | **PASSED** |

The failing action's argv shows the search path arriving while the library
reference never does:

```
"-Lnative=test/unit/cc_toolchain_runtime_lib",   <- present
...                                              <- no -Clink-arg=-ldummy
```

## Cause

`add_native_link_flags` emits the runtime libs' `-Lnative=` unconditionally but
gates the matching `-lstatic=` behind `include_link_flags`, which rustdoc sets
to False (#2467). #4080 added a compensating `-Clink-arg=-l` loop for doc tests,
but this does not work for a `static_runtime_lib`.

## Alternatives  

Injecting the flag from outside doesn't work. The archive is already in the
doc test's runfiles (via #3741), so `-Clink-arg=<its short_path>` does fix doc
tests. However, `toolchain.extra_rustc_flags` applies to every rustc invocation,
and normal `rust_test` binaries link in the execroot, where that
runfiles-relative path doesn't exist: `clang++: error: no such file or
directory`. Doc tests and normal links need *different paths to the same file*,
No single toolchain-level flag satisfies both. Per-target `rustdoc_flags`
does work, but only by hardcoding the canonical repo name and the runtime lib's
internal layout in every `rust_doc_test`. However, this is unmaintainable in any major project. 

## Changes

- `rustdoc.bzl` — extend the #4080 loop to the cc_toolchain runtime libs,
  mirroring the crate-type split in `collect_inputs`. Guarded on `cc_toolchain`
  being present (#3665).
- `rustdoc_test.bzl` — add those libs' root to `--strip_substring`. Required:
  they're built in a different configuration than the crate outputs, so
  otherwise the `-Lnative=` path stays an execroot path that doesn't exist in
  the runfiles tree the doc test runs from. Only non-empty roots are added —
  source-file runtime libs need no stripping, and an empty root would emit
  `--strip_substring=/`, which `rustdoc_test_writer` applies as a plain
  `str::replace`.

The libs already reach runfiles via `ctx.runfiles(transitive_files = action.inputs)`
thanks to #3741.

## Testing

`bazel test -- //... -//test/unit/remap_path_prefix:integration_test` on macOS:
**569 passed / 35 skipped**, against **568 / 35** before. The new doc test is
the only target that changed status; every other action was a cache hit, so
this is a provable no-op where `static_runtime_lib` is empty.
 
 The patch has also been verified against a repo that builds with hermetic-LLVM and all failing doc tests
passed. 