### PR TITLE
fix(rust): skip path mapping for unsandboxed actions

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1535,12 +1535,16 @@ def construct_arguments(
         if rustc_env_attr:
             target_has_location_expansion = has_location_expansion(rustc_env_attr.values())
 
+    # Path mapping requires sandboxed execution, which these tags disable.
+    tags = getattr(attr, "tags", [])
+    requires_unsandboxed_execution = "no-sandbox" in tags or "local" in tags
+
     args = struct(
         process_wrapper_flags = process_wrapper_flags,
         rustc_path = rustc_path,
         rustc_flags = rustc_flags,
         extra_rustc_flags = rust_flags_args,
-        supports_path_mapping = not target_has_location_expansion,
+        supports_path_mapping = not target_has_location_expansion and not requires_unsandboxed_execution,
         all = all_args,
     )
 

--- a/test/path_mapping/BUILD.bazel
+++ b/test/path_mapping/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_rust//rust:defs.bzl", "rust_test")
+
+rust_test(
+    name = "no_sandbox_test",
+    srcs = ["no_sandbox_test.rs"],
+    tags = ["no-sandbox"],
+)

--- a/test/path_mapping/no_sandbox_test.rs
+++ b/test/path_mapping/no_sandbox_test.rs
@@ -1,0 +1,4 @@
+#[test]
+fn runs_without_sandboxing() {
+    assert_eq!(2 + 2, 4);
+}


### PR DESCRIPTION
## Summary

- omit `supports-path-mapping` from Rust actions when the target is tagged `no-sandbox` or `local`
- preserve those execution tags so test execution can remain unsandboxed
- add a regression target covering Rustc and Clippy under `--experimental_output_paths=strip`

## Testing

- `bazel test --config=clippy --experimental_output_paths=strip //test/path_mapping:no_sandbox_test`
- `bazel test --config=clippy --experimental_output_paths=strip //test/unit/location_expansion:location_expansion_test_suite //test/unit/clippy:clippy_test_suite`
- repository buildifier, buildifier-lint, and typos pre-commit hooks