### PR TITLE
Preserve native final-link requirements through rust_static_library

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2245,20 +2245,24 @@ def _is_dylib(dep):
     """
     return not bool(dep.static_library or dep.pic_static_library)
 
-def _collect_nonstatic_linker_inputs(cc_info):
-    shared_linker_inputs = []
+def _collect_nonstatic_linker_inputs(cc_info, include_final_link_requirements):
+    nonstatic_linker_inputs = []
     for linker_input in cc_info.linking_context.linker_inputs.to_list():
         dylibs = [
             lib
             for lib in linker_input.libraries
             if _is_dylib(lib)
         ]
-        if dylibs:
-            shared_linker_inputs.append(cc_common.create_linker_input(
+        user_link_flags = linker_input.user_link_flags if include_final_link_requirements else []
+        additional_inputs = linker_input.additional_inputs if include_final_link_requirements else []
+        if dylibs or user_link_flags or additional_inputs:
+            nonstatic_linker_inputs.append(cc_common.create_linker_input(
                 owner = linker_input.owner,
                 libraries = depset(dylibs),
+                user_link_flags = depset(user_link_flags),
+                additional_inputs = depset(additional_inputs),
             ))
-    return shared_linker_inputs
+    return nonstatic_linker_inputs
 
 def _add_lto_flags(ctx, toolchain, args, crate):
     """Adds flags to an Args object to configure LTO for 'rustc'.
@@ -2392,13 +2396,16 @@ def establish_cc_info(ctx, attr, crate_info, toolchain, cc_toolchain, feature_co
     # Flattening is okay since crate_info.deps only records direct deps.
     for dep in crate_info.deps.to_list():
         if dep.cc_info:
-            # A Rust staticlib or shared library doesn't need to propagate linker inputs
-            # of its dependencies, except for shared libraries.
+            # Static dependencies are bundled into both crate types. Shared libraries
+            # remain final-link dependencies, as do a staticlib's user link flags.
             if crate_info.type in ["cdylib", "staticlib"]:
-                shared_linker_inputs = _collect_nonstatic_linker_inputs(dep.cc_info)
-                if shared_linker_inputs:
+                nonstatic_linker_inputs = _collect_nonstatic_linker_inputs(
+                    dep.cc_info,
+                    include_final_link_requirements = crate_info.type == "staticlib",
+                )
+                if nonstatic_linker_inputs:
                     linking_context = cc_common.create_linking_context(
-                        linker_inputs = depset(shared_linker_inputs),
+                        linker_inputs = depset(nonstatic_linker_inputs),
                     )
                     cc_infos.append(CcInfo(linking_context = linking_context))
             else:

--- a/test/linker_inputs_propagation/BUILD.bazel
+++ b/test/linker_inputs_propagation/BUILD.bazel
@@ -29,6 +29,7 @@ cc_library(
         "foo_shared.cc",
     ],
     hdrs = ["foo_shared.h"],
+    additional_linker_inputs = ["empty.so"],
     linkopts = ["-L/doesnotexist"],
 )
 
@@ -87,6 +88,13 @@ rust_static_library(
 rust_library(
     name = "rlib_uses_foo_with_redundant_linkopts",
     srcs = ["bar_uses_shared_foo_for_rust.rs"],
+    edition = "2018",
+    deps = [":foo_with_linkopts"],
+)
+
+rust_static_library(
+    name = "staticlib_uses_foo_with_linkopts",
+    srcs = ["bar_uses_shared_foo.rs"],
     edition = "2018",
     deps = [":foo_with_linkopts"],
 )
@@ -167,4 +175,33 @@ rust_binary(
         "//conditions:default": [],
     }),
     deps = [":rlib_uses_foo_with_redundant_linkopts"],
+)
+
+cc_binary(
+    name = "depends_on_foo_with_linkopts_via_staticlib",
+    srcs = ["baz.cc"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [":staticlib_uses_foo_with_linkopts"],
+)
+
+cc_library(
+    name = "resolver_linkopts",
+    linkopts = ["-lresolv"],
+)
+
+rust_static_library(
+    name = "staticlib_uses_resolver_linkopts",
+    srcs = ["resolver.rs"],
+    edition = "2021",
+    link_deps = [":resolver_linkopts"],
+)
+
+cc_test(
+    name = "depends_on_resolver_linkopts_via_staticlib",
+    srcs = ["resolver.cc"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [":staticlib_uses_resolver_linkopts"],
 )

--- a/test/linker_inputs_propagation/resolver.cc
+++ b/test/linker_inputs_propagation/resolver.cc
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <stdlib.h>
+
+extern "C" const void* resolver_symbol();
+
+int main() {
+    assert(resolver_symbol() != nullptr);
+    return EXIT_SUCCESS;
+}

--- a/test/linker_inputs_propagation/resolver.rs
+++ b/test/linker_inputs_propagation/resolver.rs
@@ -1,0 +1,10 @@
+use std::ffi::c_void;
+
+extern "C" {
+    fn ns_initparse(message: *const u8, message_length: i32, handle: *mut c_void) -> i32;
+}
+
+#[no_mangle]
+pub extern "C" fn resolver_symbol() -> *const c_void {
+    ns_initparse as *const c_void
+}

--- a/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
+++ b/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
@@ -18,7 +18,7 @@ def _static_lib_is_not_propagated_test_impl(ctx):
     link_action = [action for action in tut.actions if action.mnemonic == "CppLink"][0]
 
     lib_name = _get_lib_name(ctx, name = "foo")
-    asserts.false(env, _assert_contains_input(env, link_action.inputs, lib_name))
+    asserts.false(env, _contains_input(link_action.inputs, lib_name))
 
     return analysistest.end(env)
 
@@ -39,6 +39,20 @@ def _dependency_linkopts_are_propagated_test_impl(ctx):
     ])
     return analysistest.end(env)
 
+def _staticlib_dependency_nonstatic_inputs_are_propagated_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+    link_action = [action for action in tut.actions if action.mnemonic == "CppLink"][0]
+
+    _assert_contains_in_order(env, link_action.argv, ["-L/doesnotexist"])
+    _assert_contains_input(env, link_action.inputs, "empty.so")
+
+    # The dependency's static library is already bundled into the Rust staticlib.
+    lib_name = _get_lib_name(ctx, name = "foo_with_linkopts")
+    asserts.false(env, _contains_input(link_action.inputs, lib_name))
+
+    return analysistest.end(env)
+
 def _get_pic_suffix(ctx):
     # cc_library only produces .pic.a artifacts on linux-ish platforms in opt mode
     # (mac/win produce a single variant regardless of mode). Mirrors the same logic
@@ -50,12 +64,17 @@ def _get_pic_suffix(ctx):
     return ".pic" if ctx.var["COMPILATION_MODE"] == "opt" else ""
 
 def _assert_contains_input(env, inputs, name):
+    if _contains_input(inputs, name):
+        return
+    unittest.fail(env, "Expected {} to contain a library starting with {}".format(inputs.to_list(), name))
+
+def _contains_input(inputs, name):
     for input in inputs.to_list():
         # We cannot check for name equality because rlib outputs contain
         # a hash in their name.
         if input.basename.startswith(name):
-            return
-    unittest.fail(env, "Expected {} to contain a library starting with {}".format(inputs.to_list(), name))
+            return True
+    return False
 
 def _assert_contains_in_order(env, haystack, needle):
     for i in range(len(haystack)):
@@ -92,6 +111,13 @@ dependency_linkopts_are_propagated_test = analysistest.make(
     },
 )
 
+staticlib_dependency_nonstatic_inputs_are_propagated_test = analysistest.make(
+    _staticlib_dependency_nonstatic_inputs_are_propagated_test_impl,
+    attrs = {
+        "_windows_constraint": attr.label(default = Label("@platforms//os:windows")),
+    },
+)
+
 def _linker_inputs_propagation_test():
     static_lib_is_not_propagated_test(
         name = "depends_on_foo_via_staticlib",
@@ -118,6 +144,11 @@ def _linker_inputs_propagation_test():
         target_under_test = "//test/linker_inputs_propagation:depends_on_foo_with_redundant_linkopts",
     )
 
+    staticlib_dependency_nonstatic_inputs_are_propagated_test(
+        name = "staticlib_dependency_nonstatic_inputs_are_propagated",
+        target_under_test = "//test/linker_inputs_propagation:depends_on_foo_with_linkopts_via_staticlib",
+    )
+
 def linker_inputs_propagation_test_suite(name):
     """Entry-point macro called from the BUILD file.
 
@@ -134,5 +165,6 @@ def linker_inputs_propagation_test_suite(name):
             ":depends_on_foo_via_sharedlib",
             ":depends_on_shared_foo_via_sharedlib",
             ":dependency_linkopts_are_propagated",
+            ":staticlib_dependency_nonstatic_inputs_are_propagated",
         ],
     )


### PR DESCRIPTION
## Summary

Preserve native final-link requirements when a `rust_static_library` is consumed by C or C++.

The existing `CcInfo` construction correctly avoids propagating dependency static archives that rustc has already bundled into the Rust staticlib. However, it rebuilds each dependency `LinkerInput` using only dynamic libraries, which also drops `user_link_flags` and `additional_inputs`. Those values cannot be encoded in a `.a` archive and are still required by the eventual foreign-language final link.

## Rustc behavior being ported

This change maps rustc's staticlib orchestration onto Bazel's linking-provider model rather than inventing new linkage behavior.

At rust revision [`67854e511de21d881bb16426996cd4259d44aa2e`](https://github.com/rust-lang/rust/commit/67854e511de21d881bb16426996cd4259d44aa2e):

- [`link_staticlib`](https://github.com/rust-lang/rust/blob/67854e511de21d881bb16426996cd4259d44aa2e/compiler/rustc_codegen_ssa/src/back/link.rs#L745-L755) describes a staticlib as an archive containing upstream objects and bundled native libraries, while noting that dynamic libraries cannot be linked into the archive.
- The implementation [adds upstream Rust archives and bundled native archives](https://github.com/rust-lang/rust/blob/67854e511de21d881bb16426996cd4259d44aa2e/compiler/rustc_codegen_ssa/src/back/link.rs#L778-L830), then [collects native requirements from upstream crates and the current crate](https://github.com/rust-lang/rust/blob/67854e511de21d881bb16426996cd4259d44aa2e/compiler/rustc_codegen_ssa/src/back/link.rs#L870-L898).
- [`print_native_static_libs`](https://github.com/rust-lang/rust/blob/67854e511de21d881bb16426996cd4259d44aa2e/compiler/rustc_codegen_ssa/src/back/link.rs#L1973-L2063) converts the requirements that were not bundled into platform-appropriate final-link arguments, including native dynamic/unspecified libraries, unbundled static libraries, frameworks, and Rust dylibs.

The Rust Reference describes the same contract: a `staticlib` contains local and upstream Rust code, but its system and dynamic dependencies must be supplied when another linker consumes it. `--print=native-static-libs` exists to communicate those requirements: https://doc.rust-lang.org/reference/linkage.html#static-and-dynamic-runtimes

Rust tests this behavior directly:

- [`print-native-static-libs`](https://github.com/rust-lang/rust/blob/67854e511de21d881bb16426996cd4259d44aa2e/tests/run-make/print-native-static-libs/rmake.rs#L17-L67) builds an upstream rlib and a staticlib, then asserts that `--print=native-static-libs` contains native requirements from both the current crate and the transitive crate, including command-line `-l` arguments.
- [`staticlib-dylib-linkage`](https://github.com/rust-lang/rust/blob/67854e511de21d881bb16426996cd4259d44aa2e/tests/run-make/staticlib-dylib-linkage/rmake.rs#L14-L35) takes the emitted native link arguments, passes them to a C compiler together with the Rust staticlib, and runs the resulting executable.

## Mapping to Bazel

Rustc and Bazel represent the same boundary differently:

| rustc staticlib behavior | rules_rust/Bazel representation |
| --- | --- |
| Bundle upstream Rust objects and bundled native static libraries | Keep dependency static `LibraryToLink` values out of the exported `CcInfo`; they are already in the Rust archive |
| Leave dynamic/native system requirements for the foreign final linker | Preserve dynamic `LibraryToLink` values and dependency `user_link_flags` |
| Return final-link requirements through `--print=native-static-libs` | Return them transitively through the `rust_static_library` target's `CcInfo` |
| No equivalent filesystem dependency model | Preserve Bazel `additional_inputs`, such as linker scripts, so the final action remains hermetic |

Bazel defines `LinkerInput` as the libraries, flags, and other files passed to a linker, and defines `additional_linker_inputs` as files required specifically by the link action: https://bazel.build/rules/lib/builtins/LinkerInput and https://bazel.build/reference/be/c-cpp

The implementation preserves the complete `user_link_flags` field instead of parsing only `-l` flags. Rustc has semantic `NativeLibKind` information when producing its list; rules_rust receives platform- and toolchain-encoded Bazel linker flags. Parsing those strings here would duplicate C++ toolchain behavior and mishandle constructs such as frameworks, MSVC options, library search paths, and linker scripts.

## Root cause

`_collect_nonstatic_linker_inputs` was shared by `staticlib` and `cdylib`. It reconstructed dependency `LinkerInput` values with only non-static libraries:

- Dropping static `LibraryToLink` values is correct for both outputs because those archives were consumed while creating the Rust output.
- Dropping `user_link_flags` and `additional_inputs` is correct for `cdylib`, whose final link has already consumed them.
- Dropping them for `staticlib` is incorrect because archive creation is not the foreign final link.

Consequently, a native dependency such as `cc_library(linkopts = ["-lresolv"])` could be used while compiling a Rust staticlib, but its requirement disappeared from the `CcInfo` seen by a downstream `cc_binary` or `cc_test`.

## Change

- Continue propagating dependency dynamic libraries.
- Preserve dependency `user_link_flags` and `additional_inputs` for `staticlib` only.
- Continue excluding dependency static archives already bundled into the Rust staticlib.
- Keep `cdylib` propagation unchanged.
- Add an analysis regression covering flags, additional inputs, and exclusion of the bundled static archive.
- Add a Linux end-to-end regression using `libresolv`.

## Proof

On current upstream `main`, with only the new analysis fixture applied, the regression fails because the final `CppLink` action contains neither `-L/doesnotexist` nor `empty.so`. With the implementation change applied, the same test passes and confirms that the dependency static archive remains excluded.

The Linux regression is:

```text
cc_library(linkopts = ["-lresolv"])
        -> rust_static_library(link_deps = [...])
        -> cc_test
```

The Rust staticlib exports a function returning the address of `ns_initparse`; the C++ test references that function, forcing the relevant Rust object out of the archive.

The same production change was additionally tested in the hermeticbuild fork with its hermetic LLVM C/C++ toolchain. With the fixture but without the fix, the Linux x86_64 link fails:

```text
ld.lld: error: undefined symbol: ns_initparse
referenced by ... in archive libstaticlib_uses_resolver_linkopts.a
```

The archive contains `U ns_initparse`, confirming that the system dependency was not bundled. With the fix, the final C++ link contains `-lresolv`, succeeds, and produces an x86_64 ELF recording:

```text
NEEDED Shared library: [libresolv.so.2]
U ns_initparse
```

The undefined dynamic symbol is expected because `libresolv.so.2` is now recorded as the provider that resolves it at load time.

## Tests

```shell
bazel test //test/unit/linker_inputs_propagation:linker_inputs_propagation_test_suite
```

Baseline with test fixture only: the new regression fails. With this change: two analysis tests pass and four platform-incompatible tests are skipped on macOS.

Additional Linux x86_64 cross-link verification in the hermeticbuild fork:

```shell
bazel build --config=remote \
  --extra_toolchains=@llvm//toolchain:all \
  --platforms=@llvm//platforms:linux_x86_64 \
  //test/linker_inputs_propagation:depends_on_resolver_linkopts_via_staticlib
```

The Linux executable was cross-linked from a macOS host and inspected as an ELF; it was not executed on that host.
