### PR TITLE
Narrow C++ toolchain inputs for Rust compilation

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -733,9 +733,10 @@ def collect_inputs(
     # Pass linker inputs only for linking-like actions, not for example where
     # the output is rlib. This avoids quadratic behavior where transitive noncrates are
     # flattened on each transitive rust_library dependency.
+    is_linking_action = crate_info.type not in ("lib", "rlib") or include_linker_inputs
     libs_from_linker_inputs = []
     ambiguous_libs = {}
-    if crate_info.type not in ("lib", "rlib") or include_linker_inputs:
+    if is_linking_action:
         linker_inputs = dep_info.transitive_noncrates.to_list()
         ambiguous_libs = _disambiguate_libs(ctx.actions, toolchain, crate_info, dep_info, use_pic)
         libs_from_linker_inputs = _collect_libs_from_linker_inputs(linker_inputs, use_pic) + [
@@ -789,7 +790,7 @@ def collect_inputs(
             crate_info.compile_data,
             dep_info.transitive_proc_macro_data,
             toolchain.all_files,
-        ] + ([] if experimental_use_cc_common_link else [
+        ] + ([] if experimental_use_cc_common_link or not is_linking_action else [
             runtime_libs,
             linker_depset,
         ]),

--- a/rust/private/toolchain.bzl
+++ b/rust/private/toolchain.bzl
@@ -577,10 +577,8 @@ def _rust_toolchain_impl(ctx):
             std,
         )
 
-    # Include C++ toolchain files to ensure tools like 'ar' are available for cross-compilation
+    # C++ toolchain inputs are attached to the Rust actions that use them.
     all_files_depsets = [sysroot.all_files]
-    if cc_toolchain and cc_toolchain.all_files:
-        all_files_depsets.append(cc_toolchain.all_files)
 
     # Parse the version string once so downstream rules can branch on the
     # semver components without re-parsing. `None` for empty or non-semver


### PR DESCRIPTION
## Summary

- keep the Rust toolchain's `all_files` limited to the Rust sysroot
- add C++ linker and runtime files only to Rust actions that perform linking

## Motivation

Every Rust compilation currently inherits the complete C++ toolchain file set, including compiler headers and unrelated SDK libraries. Linking actions already declare their linker and runtime inputs separately, so carrying the full C++ toolchain through every action unnecessarily expands action inputs.
