### PR TITLE
Add RISC-V Linux host toolchain support

### DIFF
--- a/rust/platform/triple.bzl
+++ b/rust/platform/triple.bzl
@@ -137,7 +137,7 @@ def get_host_triple(repository_ctx, abi = {}):
     # Detect the host's cpu architecture
 
     supported_architectures = {
-        "linux": ["aarch64", "x86_64", "s390x", "powerpc64le"],
+        "linux": ["aarch64", "x86_64", "s390x", "powerpc64le", "riscv64"],
         "macos": ["aarch64", "x86_64"],
         "windows": ["aarch64", "x86_64"],
     }
@@ -148,6 +148,9 @@ def get_host_triple(repository_ctx, abi = {}):
 
     if arch == "ppc64le":
         arch = "powerpc64le"
+
+    if arch == "riscv64":
+        arch = "riscv64gc"
 
     if "linux" in repository_ctx.os.name:
         _validate_cpu_architecture(arch, supported_architectures["linux"])

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -60,7 +60,7 @@ SUPPORTED_T2_PLATFORM_TRIPLES = {
     "powerpc-unknown-linux-gnu": _support(std = True, host_tools = True),
     "riscv32imac-unknown-none-elf": _support(std = True, host_tools = False),
     "riscv32imc-unknown-none-elf": _support(std = True, host_tools = False),
-    "riscv64gc-unknown-linux-gnu": _support(std = True, host_tools = False),
+    "riscv64gc-unknown-linux-gnu": _support(std = True, host_tools = True),
     "riscv64gc-unknown-none-elf": _support(std = True, host_tools = False),
     "s390x-unknown-linux-gnu": _support(std = True, host_tools = True),
     "sparc64-unknown-linux-gnu": _support(std = True, host_tools = False),

--- a/rust/private/repositories.bzl
+++ b/rust/private/repositories.bzl
@@ -37,6 +37,7 @@ DEFAULT_TOOLCHAIN_TRIPLES = {
     "aarch64-pc-windows-msvc": "rust_windows_aarch64",
     "aarch64-unknown-linux-gnu": "rust_linux_aarch64",
     "powerpc64le-unknown-linux-gnu": "rust_linux_powerpc64le",
+    "riscv64gc-unknown-linux-gnu": "rust_linux_riscv64",
     "s390x-unknown-linux-gnu": "rust_linux_s390x",
     "x86_64-apple-darwin": "rust_macos_x86_64",
     "x86_64-pc-windows-msvc": "rust_windows_x86_64",


### PR DESCRIPTION
riscv64gc-unknown-linux-gnu is Rust tier 2 with host tools (https://doc.rust-lang.org/rustc/platform-support/riscv64gc-unknown-linux-gnu.html). rules_rust already listed it as a T2 target (PR #3487) but with host_tools = False, and it was missing from the default exec-triple map and from get_host_triple(). Native builds on RISC-V Linux then fail toolchain resolution with:

  No matching toolchains found for types @@rules_rust+//rust:toolchain_type

Register a rust_linux_riscv64 repository set alongside the existing Linux aarch64/x86_64/s390x/ppc64le hosts, mark the triple as having host tools, and teach get_host_triple() to accept repository_ctx.os.arch == "riscv64". The host triple is riscv64gc-unknown-linux-gnu (G + C), not the bare riscv64-unknown-linux-gnu name.