### PR TITLE
Support intra-workspace dependencies via all_crate_deps

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -591,6 +591,9 @@ def _generate_hub_and_spokes(
             workspace_name = cfg.name,
             generate_binaries = cfg.generate_binaries,
             render_config = render_config,
+            # The hub repository's `crates.bzl` lives outside the module being
+            # generated for, so first-party labels need an explicit repository.
+            cargo_lockfile_label = str(cfg.cargo_lockfile) if cfg.cargo_lockfile else None,
             repository_ctx = module_ctx,
         ),
     )

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -264,6 +264,12 @@ def _write_config_file(ctx):
             output_pkg = _get_output_package(ctx),
             workspace_name = workspace_name,
             render_config = dict(json.decode(ctx.attr.render_config)) if ctx.attr.render_config else None,
+            # Vendored output is committed into the workspace that owns the Cargo
+            # workspace, so first-party labels stay repository-relative.
+            cargo_lockfile_label = "//{}:{}".format(
+                ctx.attr.cargo_lockfile.label.package,
+                ctx.attr.cargo_lockfile.label.name,
+            ) if ctx.attr.cargo_lockfile else None,
         ),
     )
 
@@ -285,6 +291,7 @@ def generate_config_file(
         output_pkg,
         workspace_name,
         render_config,
+        cargo_lockfile_label = None,
         repository_ctx = None):
     """Writes the rendering config to cargo-bazel-config.json.
 
@@ -301,6 +308,9 @@ def generate_config_file(
         output_pkg: The path to the package containing the build files.
         workspace_name (str): The name of the workspace.
         render_config: The render config to use.
+        cargo_lockfile_label (str, optional): The label of the `cargo_lockfile`. Its repository
+            is where `all_crate_deps(first_party = True)` looks for the Cargo workspace's own
+            crates.
         repository_ctx (repository_ctx, optional): A repository context object
             used for enabling certain functionality.
 
@@ -378,6 +388,7 @@ def generate_config_file(
         render_config = render_config,
         supported_platform_triples = supported_platform_triples,
         repository_name = repository_name or ctx.label.name,
+        cargo_lockfile_label = cargo_lockfile_label,
         repository_ctx = repository_ctx,
     )
 

--- a/crate_universe/private/generate_utils.bzl
+++ b/crate_universe/private/generate_utils.bzl
@@ -218,12 +218,15 @@ def _read_cargo_config(repository_ctx):
         return repository_ctx.read(config)
     return None
 
-def _update_render_config(config, repository_name):
-    """Add the repository name to the render config
+def _update_render_config(config, repository_name, cargo_lockfile_label):
+    """Add rendering details that come from the rule rather than the user
 
     Args:
         config (dict): A `render_config` struct
         repository_name (str): The name of the repository that owns the config
+        cargo_lockfile_label (str): The label of the rule's `cargo_lockfile`, or None. Its
+            repository is what `all_crate_deps(first_party = True)` renders labels against,
+            since that is the Bazel repository holding the Cargo workspace's own crates.
 
     Returns:
         struct: An updated `render_config`.
@@ -231,6 +234,9 @@ def _update_render_config(config, repository_name):
 
     # Add the repository name as it's very relevant to rendering.
     config.update({"repository_name": repository_name})
+
+    if cargo_lockfile_label:
+        config.update({"cargo_lockfile_label": cargo_lockfile_label})
 
     return struct(**config)
 
@@ -256,6 +262,7 @@ def compile_config(
         render_config,
         supported_platform_triples,
         repository_name,
+        cargo_lockfile_label = None,
         repository_ctx = None):
     """Create a config file for generating crate targets
 
@@ -271,6 +278,9 @@ def compile_config(
         render_config (dict): The deserialized dict of the `render_config` function.
         supported_platform_triples (list): A list of platform triples
         repository_name (str): The name of the repository being generated
+        cargo_lockfile_label (str, optional): The label of the rule's `cargo_lockfile`. Used to
+            locate the Bazel repository that owns the Cargo workspace's own crates when
+            rendering `all_crate_deps(first_party = True)`.
         repository_ctx (repository_ctx, optional): A repository context object used for enabling
             certain functionality.
 
@@ -310,6 +320,7 @@ def compile_config(
         rendering = _update_render_config(
             config = render_config,
             repository_name = repository_name,
+            cargo_lockfile_label = cargo_lockfile_label,
         ),
         supported_platform_triples = supported_platform_triples,
     )
@@ -335,6 +346,9 @@ def generate_config(repository_ctx):
         render_config = _get_render_config(repository_ctx),
         supported_platform_triples = repository_ctx.attr.supported_platform_triples,
         repository_name = repository_ctx.name,
+        # The hub repository's `crates.bzl` lives outside the workspace being
+        # generated for, so first-party labels need an explicit repository.
+        cargo_lockfile_label = str(repository_ctx.attr.cargo_lockfile),
         repository_ctx = repository_ctx,
     )
 

--- a/crate_universe/src/api/lockfile.rs
+++ b/crate_universe/src/api/lockfile.rs
@@ -170,6 +170,7 @@ mod test {
             got_pkg_a.normal_deps().values(),
             vec![
                 CrateDependency {
+                    workspace_member: false,
                     id: CrateId {
                         name: String::from("anyhow"),
                         version: Version::new(1, 0, 69),
@@ -179,6 +180,7 @@ mod test {
                     local_path: None,
                 },
                 CrateDependency {
+                    workspace_member: false,
                     id: CrateId {
                         name: String::from("reqwest"),
                         version: Version::new(0, 11, 14),

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -132,6 +132,21 @@ pub(crate) struct RenderConfig {
     /// continue to write subpackage `BUILD.bazel`s into the hub repo directly.
     #[serde(default)]
     pub(crate) crates_vendor_synthesizes_subpackages: bool,
+
+    /// Internal: the label of the rule's `cargo_lockfile`. Only its repository
+    /// is used, to locate the Bazel repository holding the Cargo workspace's
+    /// own crates so `all_crate_deps(first_party = True)` can emit labels for
+    /// them. Injected by the rules, never set by users — a workspace member's
+    /// Bazel package is already known (`Context::workspace_members`); the
+    /// repository is the one piece the renderer cannot infer.
+    ///
+    /// Excluded from the digest by [`crate::lockfile::Digest::new`], mirroring
+    /// `label_injection_mapping`: canonical repository names are consumer-
+    /// specific, so hashing this would make a root-level
+    /// `single_version_override` demand a producer-side repin that a
+    /// registry-distributed lockfile in a read-only cache can never perform.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) cargo_lockfile_label: Option<Label>,
 }
 
 // Default is manually implemented so that the default values match the default
@@ -156,6 +171,7 @@ impl Default for RenderConfig {
             generate_rules_license_metadata: default_generate_rules_license_metadata(),
             incompatible_no_root_alias_targets: false,
             crates_vendor_synthesizes_subpackages: false,
+            cargo_lockfile_label: Option::default(),
         }
     }
 }

--- a/crate_universe/src/context.rs
+++ b/crate_universe/src/context.rs
@@ -127,9 +127,16 @@ impl Context {
             })
             .collect::<Result<BTreeMap<CrateId, String>>>()?;
 
+        // Workspace members are deliberately absent here: no repository is
+        // generated for a crate that lives in the Cargo workspace, so listing
+        // one as a direct dependency would only add noise to the lockfile.
         let add_crate_ids = |crates: &mut BTreeSet<CrateId>,
                              deps: &Select<BTreeSet<Dependency>>| {
-            for dep in deps.values() {
+            for dep in deps
+                .values()
+                .into_iter()
+                .filter(|dep| !dep.workspace_member)
+            {
                 crates.insert(CrateId::from(
                     &annotations.metadata.packages[&dep.package_id],
                 ));

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -12,8 +12,8 @@ use crate::metadata::{
     CrateAnnotation, Dependency, PairedExtras, SourceAnnotation, TreeResolverMetadata,
 };
 use crate::select::Select;
-use crate::utils::sanitize_module_name;
 use crate::utils::starlark::{Glob, Label};
+use crate::utils::{is_false, sanitize_module_name};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct CrateDependency {
@@ -32,6 +32,12 @@ pub struct CrateDependency {
     /// `[dependencies]` table and the `[patches]` table so they can be used in rendering.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) local_path: Option<Utf8PathBuf>,
+
+    /// Whether the dependency is another member of the same Cargo workspace. The
+    /// rendered dependency maps keep these separate from third-party crates so
+    /// `all_crate_deps(first_party = True)` can opt into them.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub workspace_member: bool,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Clone)]
@@ -409,6 +415,7 @@ impl CrateContext {
                 id: CrateId::new(pkg.name.clone(), pkg.version.clone()),
                 target,
                 alias: dep.alias,
+                workspace_member: dep.workspace_member,
                 local_path: match source_annotations.get(&dep.package_id) {
                     Some(SourceAnnotation::Path { path }) => Some(path.clone()),
                     _ => None,

--- a/crate_universe/src/context/platforms.rs
+++ b/crate_universe/src/context/platforms.rs
@@ -132,6 +132,7 @@ mod test {
         let mut deps: Select<BTreeSet<CrateDependency>> = Select::default();
         deps.insert(
             CrateDependency {
+                workspace_member: false,
                 id: CrateId::new("mock_crate_b".to_owned(), VERSION_ZERO_ONE_ZERO),
                 target: "mock_crate_b".to_owned(),
                 alias: None,
@@ -191,6 +192,7 @@ mod test {
         let mut deps: Select<BTreeSet<CrateDependency>> = Select::default();
         deps.insert(
             CrateDependency {
+                workspace_member: false,
                 id: CrateId::new("mock_crate_b".to_owned(), VERSION_ZERO_ONE_ZERO),
                 target: "mock_crate_b".to_owned(),
                 alias: None,
@@ -278,6 +280,7 @@ mod test {
         let mut deps: Select<BTreeSet<CrateDependency>> = Select::default();
         deps.insert(
             CrateDependency {
+                workspace_member: false,
                 id: CrateId::new("mock_crate_b".to_owned(), VERSION_ZERO_ONE_ZERO),
                 target: "mock_crate_b".to_owned(),
                 alias: None,
@@ -345,6 +348,7 @@ mod test {
         let mut deps: Select<BTreeSet<CrateDependency>> = Select::default();
         deps.insert(
             CrateDependency {
+                workspace_member: false,
                 id: CrateId::new("mock_crate_b".to_owned(), VERSION_ZERO_ONE_ZERO),
                 target: "mock_crate_b".to_owned(),
                 alias: None,

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -13,7 +13,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as Sha2Digest, Sha256};
 
-use crate::config::Config;
+use crate::config::{Config, RenderConfig};
 use crate::context::Context;
 use crate::metadata::Cargo;
 use crate::splicing::{SplicingManifest, SplicingMetadata};
@@ -78,9 +78,15 @@ impl Digest {
         // `single_version_override` would shift the canonical names, change
         // the digest, and force a producer-side repin to recover — which is
         // impossible for registry-distributed producers whose lockfile lives
-        // in a read-only bzlmod cache.
+        // in a read-only bzlmod cache. `rendering.cargo_lockfile_label` carries
+        // a consumer-side canonical repository name too, so it is cleared for
+        // exactly the same reason.
         let config_for_hash = Config {
             label_injection_mapping: Default::default(),
+            rendering: RenderConfig {
+                cargo_lockfile_label: None,
+                ..config.rendering.clone()
+            },
             ..config.clone()
         };
 

--- a/crate_universe/src/metadata/dependency.rs
+++ b/crate_universe/src/metadata/dependency.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::CrateId;
 use crate::metadata::TreeResolverMetadata;
 use crate::select::Select;
-use crate::utils::sanitize_module_name;
+use crate::utils::{is_false, sanitize_module_name};
 
 /// A representation of a crate dependency
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -25,6 +25,13 @@ pub(crate) struct Dependency {
 
     /// The alias for the dependency from the perspective of the current package
     pub(crate) alias: Option<String>,
+
+    /// Whether the dependency is another member of the same Cargo workspace.
+    /// These are tracked but kept out of the third-party dependency maps, since
+    /// no repository is generated for them; `all_crate_deps(first_party = True)`
+    /// is what opts into them.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub(crate) workspace_member: bool,
 }
 
 /// A collection of [Dependency]s sorted by dependency kind.
@@ -50,8 +57,6 @@ impl DependencySet {
             let (dev, normal) = node
                 .deps
                 .iter()
-                // Do not track workspace members as dependencies. Users are expected to maintain those connections
-                .filter(|dep| !is_workspace_member(dep, metadata))
                 .filter(|dep| is_lib_package(&metadata[&dep.pkg]))
                 .filter(|dep| is_normal_dependency(dep) || is_dev_dependency(dep))
                 .partition(|dep| is_dev_dependency(dep));
@@ -72,8 +77,6 @@ impl DependencySet {
             let (dev, normal) = node
                 .deps
                 .iter()
-                // Do not track workspace members as dependencies. Users are expected to maintain those connections
-                .filter(|dep| !is_workspace_member(dep, metadata))
                 .filter(|dep| is_proc_macro_package(&metadata[&dep.pkg]))
                 .filter(|dep| is_normal_dependency(dep) || is_dev_dependency(dep))
                 .partition(|dep| is_dev_dependency(dep));
@@ -96,8 +99,6 @@ impl DependencySet {
             let (proc_macro, normal) = node
                 .deps
                 .iter()
-                // Do not track workspace members as dependencies. Users are expected to maintain those connections
-                .filter(|dep| !is_workspace_member(dep, metadata))
                 .filter(|dep| is_build_dependency(dep))
                 .filter(|dep| !is_dev_dependency(dep))
                 .partition(|dep| is_proc_macro_package(&metadata[&dep.pkg]));
@@ -202,6 +203,7 @@ fn collect_deps_selectable(
             .expect("Nodes Dependencies are expected to exclusively be library-like targets");
         let alias = get_target_alias(&dep.name, dep_pkg);
         let crate_id = CrateId::from(dep_pkg);
+        let workspace_member = is_workspace_member(dep, metadata);
 
         for kind_info in &dep.dep_kinds {
             if kind_info.kind != kind {
@@ -219,6 +221,7 @@ fn collect_deps_selectable(
                                 package_id: dep.pkg.clone(),
                                 target_name: target_name.clone(),
                                 alias: alias.clone(),
+                                workspace_member,
                             };
                             select.insert(dependency, config);
                         }
@@ -229,6 +232,7 @@ fn collect_deps_selectable(
                     package_id: dep.pkg.clone(),
                     target_name: target_name.clone(),
                     alias: alias.clone(),
+                    workspace_member,
                 };
                 select.insert(
                     dependency,
@@ -950,6 +954,51 @@ mod test {
                 .count(),
             0,
             "`mio` is a platform specific dependency and therefore should not be identified under the common configuration."
+        );
+    }
+
+    #[test]
+    fn workspace_member_deps_are_tracked_and_tagged() {
+        let metadata = metadata::workspace_path();
+
+        let child_b = find_metadata_node("child_b", &metadata);
+        let depset = DependencySet::new_for_node(child_b, &metadata, None);
+
+        // `child_b` depends on `child_a` through `[workspace.dependencies]`.
+        // The edge is recorded so `all_crate_deps(first_party = True)` has
+        // something to render, and tagged so the third-party dependency maps
+        // can leave it out.
+        let child_a: Vec<_> = depset
+            .normal_deps
+            .items()
+            .into_iter()
+            .filter(|(_, dep)| dep.target_name == "child_a")
+            .collect();
+
+        assert_eq!(child_a.len(), 1);
+        let (configuration, dep) = &child_a[0];
+        assert_eq!(configuration, &None);
+        assert!(
+            dep.workspace_member,
+            "`child_a` is a member of the same Cargo workspace as `child_b`"
+        );
+    }
+
+    #[test]
+    fn third_party_deps_are_not_tagged_as_workspace_members() {
+        let metadata = metadata::common();
+
+        let node = find_metadata_node("common", &metadata);
+        let depset = DependencySet::new_for_node(node, &metadata, None);
+
+        assert!(!depset.normal_deps.items().is_empty());
+        assert!(
+            depset
+                .normal_deps
+                .items()
+                .iter()
+                .all(|(_, dep)| !dep.workspace_member),
+            "no dependency of a single-package workspace can be a workspace member"
         );
     }
 }

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -2260,6 +2260,7 @@ mod test {
                 library_target_name: Some("library_name".into()),
                 common_attrs: CommonAttributes {
                     deps: Select::from_value(BTreeSet::from([CrateDependency {
+                        workspace_member: false,
                         id: crate_id,
                         target: "target".into(),
                         // this is identical to what we have in the `name` attribute
@@ -2389,12 +2390,14 @@ mod test {
                     deps: Select::from_value(BTreeSet::from([
                         // These two dependencies are identical, except one is aliased.
                         CrateDependency {
+                            workspace_member: false,
                             id: dependency_id.clone(),
                             target: "my_dependency".into(),
                             alias: None,
                             local_path: None,
                         },
                         CrateDependency {
+                            workspace_member: false,
                             id: dependency_id,
                             target: "my_dependency".into(),
                             alias: Some("my_dependency_other".into()),
@@ -2548,6 +2551,142 @@ mod test {
         assert!(
             binary_section[proc_macro_deps_pos..].contains(":my_proc_macro"),
             "proc-macro lib must appear in proc_macro_deps:\n{binary_section}"
+        );
+    }
+
+    /// Renders a workspace's `crates.bzl` with the given `cargo_lockfile` label,
+    /// which is what first-party dependency labels resolve against.
+    fn render_crates_bzl(
+        metadata: cargo_metadata::Metadata,
+        lockfile: cargo_lock::Lockfile,
+        cargo_lockfile_label: Option<Label>,
+    ) -> String {
+        let render_config = RenderConfig {
+            cargo_lockfile_label,
+            ..Arc::<RenderConfig>::into_inner(mock_render_config(None)).unwrap()
+        };
+
+        let annotations = Annotations::new(
+            metadata,
+            &None,
+            lockfile,
+            Config {
+                rendering: render_config.clone(),
+                ..Default::default()
+            },
+            Utf8Path::new("/tmp/bazelworkspace"),
+        )
+        .unwrap();
+        let context = Context::new(annotations, false).unwrap();
+
+        let renderer = Renderer::new(Arc::new(render_config), mock_supported_platform_triples());
+        let output = renderer.render(&context, None).unwrap();
+
+        output.get(&PathBuf::from("crates.bzl")).unwrap().clone()
+    }
+
+    #[test]
+    fn first_party_deps_are_rendered_separately() {
+        let crates_bzl = render_crates_bzl(
+            test::metadata::workspace_path(),
+            test::lockfile::workspace_path(),
+            Some(Label::Absolute {
+                repository: starlark::Repository::Canonical("test_repo".to_owned()),
+                package: String::new(),
+                target: "Cargo.lock".to_owned(),
+            }),
+        );
+
+        let expected = indoc! {r#"
+            _FIRST_PARTY_NORMAL_DEPENDENCIES = {
+                "child_a": {
+                },
+                "child_b": {
+                    _COMMON_CONDITION: {
+                        "child_a": Label("@@test_repo//child_a:child_a"),
+                    },
+                },
+                "": {
+                },
+            }
+        "#};
+        assert!(
+            crates_bzl.contains(expected),
+            "{crates_bzl}
+ does not contain {expected}"
+        );
+
+        // The third-party maps stay free of workspace members: no repository is
+        // generated for `child_a`, so a label into the hub would not resolve.
+        let (_, third_party) = crates_bzl
+            .split_once("_NORMAL_DEPENDENCIES = {")
+            .expect("`crates.bzl` always defines the normal dependency map");
+        let (third_party, _) = third_party.split_once("\n}").unwrap();
+        assert!(
+            !third_party.contains("\"child_a\": Label("),
+            "third party dependency map should not depend on `child_a`: {third_party}"
+        );
+    }
+
+    /// The integration test's `cargo_lockfile` is `//:Cargo.Bazel.lock` in a root
+    /// module, which reaches the renderer as `@@//:Cargo.Bazel.lock`. First-party
+    /// labels then have to come out as `@@//<package>:<target>` so they resolve
+    /// against the workspace being built rather than the hub repository.
+    #[test]
+    fn first_party_deps_of_a_root_module() {
+        let cargo_lockfile_label = Label::from_str("@@//:Cargo.Bazel.lock").unwrap();
+        assert_eq!(
+            cargo_lockfile_label.repository(),
+            Some(&starlark::Repository::Canonical(String::new()))
+        );
+
+        let crates_bzl = render_crates_bzl(
+            test::metadata::workspace_path(),
+            test::lockfile::workspace_path(),
+            Some(cargo_lockfile_label),
+        );
+
+        let expected = r#""child_a": Label("@@//child_a:child_a"),"#;
+        assert!(
+            crates_bzl.contains(expected),
+            "{crates_bzl}
+ does not contain {expected}"
+        );
+    }
+
+    #[test]
+    fn first_party_deps_are_empty_without_a_cargo_lockfile_label() {
+        // A config predating the injected label still renders; the first-party
+        // maps are simply empty, so `first_party = True` yields nothing rather
+        // than a broken label.
+        let crates_bzl = render_crates_bzl(
+            test::metadata::workspace_path(),
+            test::lockfile::workspace_path(),
+            None,
+        );
+
+        assert!(crates_bzl.contains("_FIRST_PARTY_NORMAL_DEPENDENCIES = {}"));
+        assert!(!crates_bzl.contains("test_repo"));
+    }
+
+    #[test]
+    fn first_party_maps_have_no_entries_without_intra_workspace_deps() {
+        // A workspace whose crates do not depend on each other still renders the
+        // maps, since the `cargo_lockfile` label is present, but they carry no
+        // entries for `all_crate_deps(first_party = True)` to return.
+        let crates_bzl = render_crates_bzl(
+            test::metadata::common(),
+            test::lockfile::common(),
+            Some(Label::from_str("@@//:Cargo.lock").unwrap()),
+        );
+
+        let (_, first_party) = crates_bzl
+            .split_once("\n_FIRST_PARTY_NORMAL_DEPENDENCIES = ")
+            .expect("`crates.bzl` always defines the first party dependency maps");
+        let (first_party, _) = first_party.split_once("\n}").unwrap();
+        assert!(
+            !first_party.contains("Label("),
+            "expected no first party dependencies in: {first_party}"
         );
     }
 }

--- a/crate_universe/src/rendering/template_engine.rs
+++ b/crate_universe/src/rendering/template_engine.rs
@@ -20,6 +20,10 @@ use crate::utils::target_triple::TargetTriple;
 pub(crate) struct TemplateEngine {
     engine: tera::Tera,
     context: tera::Context,
+
+    /// Retained so `crates.bzl` can tell whether first-party labels are
+    /// renderable at all. See [`RenderConfig::cargo_lockfile_label`].
+    cargo_lockfile_label: Option<Label>,
 }
 
 impl TemplateEngine {
@@ -112,6 +116,10 @@ impl TemplateEngine {
             module_label_fn_generator(render_config.crates_module_template.clone()),
         );
         tera.register_function(
+            "first_party_label",
+            first_party_label_fn_generator(render_config.cargo_lockfile_label.clone()),
+        );
+        tera.register_function(
             "local_crate_mirror_options_json",
             local_crate_mirror_options_json_fn_generator(
                 Arc::clone(&render_config),
@@ -137,6 +145,7 @@ impl TemplateEngine {
         Self {
             engine: tera,
             context,
+            cargo_lockfile_label: render_config.cargo_lockfile_label.clone(),
         }
     }
 
@@ -166,6 +175,10 @@ impl TemplateEngine {
         context.insert("context", data);
         context.insert("platforms", platforms);
         context.insert("generator", &generator);
+        context.insert(
+            "render_first_party_deps",
+            &matches!(self.cargo_lockfile_label, Some(Label::Absolute { .. })),
+        );
 
         self.engine
             .render("module_bzl.j2", &context)
@@ -278,6 +291,41 @@ fn crate_alias_fn_generator(template: String, repository_name: String) -> impl t
             )) {
                 Ok(v) => Ok(v),
                 Err(_) => Err(tera::Error::msg("Failed to generate crate's label")),
+            }
+        },
+    )
+}
+
+/// Renders the label of a first-party target, meaning a crate that is a member
+/// of the same Cargo workspace as the crate depending on it. The `package` comes
+/// from the member's location in the Bazel workspace
+/// ([`crate::context::Context::workspace_members`]) and the `target` from the
+/// dependency's library target name. The repository is taken from the rule's
+/// `cargo_lockfile` label, which is what ties the generated hub back to the
+/// workspace that owns those targets.
+fn first_party_label_fn_generator(cargo_lockfile_label: Option<Label>) -> impl tera::Function {
+    Box::new(
+        move |args: &HashMap<String, Value>| -> tera::Result<Value> {
+            let package = parse_tera_param!("package", String, args);
+            let target = parse_tera_param!("target", String, args);
+
+            let repository = match &cargo_lockfile_label {
+                Some(Label::Absolute { repository, .. }) => repository.clone(),
+                _ => return Err(tera::Error::msg(
+                    "Cannot render a first party label without an absolute `cargo_lockfile` label",
+                )),
+            };
+
+            match to_value(
+                Label::Absolute {
+                    repository,
+                    package,
+                    target,
+                }
+                .to_string(),
+            ) {
+                Ok(v) => Ok(v),
+                Err(_) => Err(tera::Error::msg("Failed to generate first party label")),
             }
         },
     )

--- a/crate_universe/src/rendering/templates/module_bzl.j2
+++ b/crate_universe/src/rendering/templates/module_bzl.j2
@@ -163,6 +163,7 @@ def all_crate_deps(
         proc_macro_dev = False,
         build = False,
         build_proc_macro = False,
+        first_party = False,
         package_name = {{ default_package_name }}):
     """Finds the fully qualified label of all requested direct crate dependencies \
     for the package where this macro is called.
@@ -183,6 +184,15 @@ def all_crate_deps(
             in the output list.
         build_proc_macro (bool, optional): If True, build proc_macro dependencies are
             included in the output list.
+        first_party (bool, optional): If True, dependencies on other crates of this Cargo
+            workspace are included in the output list alongside the third party ones, for
+            each dependency kind requested. Each such crate is expected to have a Bazel
+            target named after its Cargo library target, in the Bazel package matching its
+            location in the Cargo workspace. Defaults to False, leaving those dependencies
+            for you to declare by hand. Note that intra-workspace dependencies are only
+            recorded in lockfiles written by a version of `crate_universe` that supports
+            them, so a lockfile predating this feature yields nothing here until it is
+            repinned.
         package_name (str, optional): The package name of the set of dependencies to look up.
             Defaults to `native.package_name()` when unset.
 
@@ -197,20 +207,34 @@ def all_crate_deps(
     all_dependency_maps = []
     if normal:
         all_dependency_maps.append(_NORMAL_DEPENDENCIES)
+        if first_party:
+            all_dependency_maps.append(_FIRST_PARTY_NORMAL_DEPENDENCIES)
     if normal_dev:
         all_dependency_maps.append(_NORMAL_DEV_DEPENDENCIES)
+        if first_party:
+            all_dependency_maps.append(_FIRST_PARTY_NORMAL_DEV_DEPENDENCIES)
     if proc_macro:
         all_dependency_maps.append(_PROC_MACRO_DEPENDENCIES)
+        if first_party:
+            all_dependency_maps.append(_FIRST_PARTY_PROC_MACRO_DEPENDENCIES)
     if proc_macro_dev:
         all_dependency_maps.append(_PROC_MACRO_DEV_DEPENDENCIES)
+        if first_party:
+            all_dependency_maps.append(_FIRST_PARTY_PROC_MACRO_DEV_DEPENDENCIES)
     if build:
         all_dependency_maps.append(_BUILD_DEPENDENCIES)
+        if first_party:
+            all_dependency_maps.append(_FIRST_PARTY_BUILD_DEPENDENCIES)
     if build_proc_macro:
         all_dependency_maps.append(_BUILD_PROC_MACRO_DEPENDENCIES)
+        if first_party:
+            all_dependency_maps.append(_FIRST_PARTY_BUILD_PROC_MACRO_DEPENDENCIES)
 
     # Default to always using normal dependencies
     if not all_dependency_maps:
         all_dependency_maps.append(_NORMAL_DEPENDENCIES)
+        if first_party:
+            all_dependency_maps.append(_FIRST_PARTY_NORMAL_DEPENDENCIES)
 
     dependencies = _flatten_dependency_maps(all_dependency_maps).pop(package_name, None)
 
@@ -319,29 +343,58 @@ _CRATE_EDITIONS = {
     {%- endfor %}
 }
 
-_NORMAL_DEPENDENCIES = {% set deps_type = "normal" %}{% include "partials/module/deps_map.j2" %}
+_NORMAL_DEPENDENCIES = {% set deps_type = "normal" %}{% set first_party = false %}{% include "partials/module/deps_map.j2" %}
 
 _NORMAL_ALIASES = {% set deps_type = "normal" %}{% include "partials/module/aliases_map.j2" %}
 
-_NORMAL_DEV_DEPENDENCIES = {% set deps_type = "normal-dev" %}{% include "partials/module/deps_map.j2" %}
+_NORMAL_DEV_DEPENDENCIES = {% set deps_type = "normal-dev" %}{% set first_party = false %}{% include "partials/module/deps_map.j2" %}
 
 _NORMAL_DEV_ALIASES = {% set deps_type = "normal-dev" %}{% include "partials/module/aliases_map.j2" %}
 
-_PROC_MACRO_DEPENDENCIES = {% set deps_type = "proc-macro" %}{% include "partials/module/deps_map.j2" %}
+_PROC_MACRO_DEPENDENCIES = {% set deps_type = "proc-macro" %}{% set first_party = false %}{% include "partials/module/deps_map.j2" %}
 
 _PROC_MACRO_ALIASES = {% set deps_type = "proc-macro-dev" %}{% include "partials/module/aliases_map.j2" %}
 
-_PROC_MACRO_DEV_DEPENDENCIES = {% set deps_type = "proc-macro-dev" %}{% include "partials/module/deps_map.j2" %}
+_PROC_MACRO_DEV_DEPENDENCIES = {% set deps_type = "proc-macro-dev" %}{% set first_party = false %}{% include "partials/module/deps_map.j2" %}
 
 _PROC_MACRO_DEV_ALIASES = {% set deps_type = "normal-dev" %}{% include "partials/module/aliases_map.j2" %}
 
-_BUILD_DEPENDENCIES = {% set deps_type = "build" %}{% include "partials/module/deps_map.j2" %}
+_BUILD_DEPENDENCIES = {% set deps_type = "build" %}{% set first_party = false %}{% include "partials/module/deps_map.j2" %}
 
 _BUILD_ALIASES = {% set deps_type = "build" %}{% include "partials/module/aliases_map.j2" %}
 
-_BUILD_PROC_MACRO_DEPENDENCIES = {% set deps_type = "build-proc-macro" %}{% include "partials/module/deps_map.j2" %}
+_BUILD_PROC_MACRO_DEPENDENCIES = {% set deps_type = "build-proc-macro" %}{% set first_party = false %}{% include "partials/module/deps_map.j2" %}
 
 _BUILD_PROC_MACRO_ALIASES = {% set deps_type = "build-proc-macro" %}{% include "partials/module/aliases_map.j2" %}
+
+# Dependencies on other crates of this Cargo workspace, consumed only when
+# `all_crate_deps` is called with `first_party = True`. Empty when the rules did
+# not supply a `cargo_lockfile` label to resolve those crates against.
+{%- if render_first_party_deps %}
+_FIRST_PARTY_NORMAL_DEPENDENCIES = {% set deps_type = "normal" %}{% set first_party = true %}{% include "partials/module/deps_map.j2" %}
+
+_FIRST_PARTY_NORMAL_DEV_DEPENDENCIES = {% set deps_type = "normal-dev" %}{% set first_party = true %}{% include "partials/module/deps_map.j2" %}
+
+_FIRST_PARTY_PROC_MACRO_DEPENDENCIES = {% set deps_type = "proc-macro" %}{% set first_party = true %}{% include "partials/module/deps_map.j2" %}
+
+_FIRST_PARTY_PROC_MACRO_DEV_DEPENDENCIES = {% set deps_type = "proc-macro-dev" %}{% set first_party = true %}{% include "partials/module/deps_map.j2" %}
+
+_FIRST_PARTY_BUILD_DEPENDENCIES = {% set deps_type = "build" %}{% set first_party = true %}{% include "partials/module/deps_map.j2" %}
+
+_FIRST_PARTY_BUILD_PROC_MACRO_DEPENDENCIES = {% set deps_type = "build-proc-macro" %}{% set first_party = true %}{% include "partials/module/deps_map.j2" %}
+{%- else %}
+_FIRST_PARTY_NORMAL_DEPENDENCIES = {}
+
+_FIRST_PARTY_NORMAL_DEV_DEPENDENCIES = {}
+
+_FIRST_PARTY_PROC_MACRO_DEPENDENCIES = {}
+
+_FIRST_PARTY_PROC_MACRO_DEV_DEPENDENCIES = {}
+
+_FIRST_PARTY_BUILD_DEPENDENCIES = {}
+
+_FIRST_PARTY_BUILD_PROC_MACRO_DEPENDENCIES = {}
+{%- endif %}
 
 _CONDITIONS = {
 {%- for condition, triples in platforms %}

--- a/crate_universe/src/rendering/templates/partials/module/deps_map.j2
+++ b/crate_universe/src/rendering/templates/partials/module/deps_map.j2
@@ -28,9 +28,17 @@
         {%- if deps_set.common | length %}
         _COMMON_CONDITION: {
             {%- for dep in deps_set.common %}
-            {%- if dep.id in context.workspace_members %}{% continue %}}{% endif %}{# Workspace member repositories are not defined, skip adding their labels here #}
+            {%- if first_party %}
+            {%- if not dep.workspace_member or dep.id not in context.workspace_members %}{% continue %}}{% endif %}{# Only crates of this Cargo workspace belong here, and only those with a known Bazel package #}
+            {%- else %}
+            {%- if dep.workspace_member or dep.id in context.workspace_members %}{% continue %}}{% endif %}{# Crates of this Cargo workspace have no repository defined, skip adding their labels here #}
+            {%- endif %}
             {%- set crate = context.crates | get(key=dep.id) %}
+            {%- if first_party %}
+            "{{ dep | get(key="alias", default=crate.name) }}": Label("{{ first_party_label(package = context.workspace_members | get(key=dep.id), target = dep.target) }}"),
+            {%- else %}
             "{{ dep | get(key="alias", default=crate.name) }}": Label("{{ crate_alias(name = crate.name, version = crate.version, target = dep.target) }}"),
+            {%- endif %}
             {%- endfor %}
         },
         {%- endif %}
@@ -38,9 +46,17 @@
         {%- for condition, deps in deps_set.selects %}
         "{{ condition | addslashes }}": {
             {%- for dep in deps %}
-            {%- if dep.id in context.workspace_members %}{% continue %}}{% endif %}{# Workspace member repositories are not defined, skip adding their labels here #}
+            {%- if first_party %}
+            {%- if not dep.workspace_member or dep.id not in context.workspace_members %}{% continue %}}{% endif %}
+            {%- else %}
+            {%- if dep.workspace_member or dep.id in context.workspace_members %}{% continue %}}{% endif %}{# Crates of this Cargo workspace have no repository defined, skip adding their labels here #}
+            {%- endif %}
             {%- set crate = context.crates | get(key=dep.id) %}
+            {%- if first_party %}
+            "{{ dep | get(key="alias", default=crate.name) }}": Label("{{ first_party_label(package = context.workspace_members | get(key=dep.id), target = dep.target) }}"),
+            {%- else %}
             "{{ dep | get(key="alias", default=crate.name) }}": Label("{{ crate_alias(name = crate.name, version = crate.version, target = dep.target) }}"),
+            {%- endif %}
             {%- endfor %}
         },
         {%- endfor %}

--- a/crate_universe/src/test.rs
+++ b/crate_universe/src/test.rs
@@ -212,6 +212,14 @@ pub(crate) mod metadata {
         )))
         .unwrap()
     }
+
+    pub(crate) fn workspace_path() -> cargo_metadata::Metadata {
+        serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_data/metadata/workspace_path/metadata.json"
+        )))
+        .unwrap()
+    }
 }
 
 pub(crate) mod lockfile {
@@ -301,6 +309,14 @@ pub(crate) mod lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/workspace_build_scripts_deps/Cargo.lock"
+        )))
+        .unwrap()
+    }
+
+    pub(crate) fn workspace_path() -> cargo_lock::Lockfile {
+        cargo_lock::Lockfile::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_data/metadata/workspace_path/Cargo.lock"
         )))
         .unwrap()
     }

--- a/crate_universe/src/utils.rs
+++ b/crate_universe/src/utils.rs
@@ -9,6 +9,12 @@ pub(crate) const CRATES_IO_INDEX_URL: &str = "https://github.com/rust-lang/crate
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+/// A `serde` `skip_serializing_if` predicate for `bool` fields that default to
+/// `false`, so they stay out of serialized lockfiles unless actually set.
+pub(crate) fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 /// Convert a string into a valid crate module name by applying transforms to invalid characters
 pub(crate) fn sanitize_module_name(name: &str) -> String {
     name.replace('-', "_")

--- a/crate_universe/tests/integration/cargo_workspace/cargo-bazel-lock.json
+++ b/crate_universe/tests/integration/cargo_workspace/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0d1fb050eb87a6345ce8da4ff8f7ed41d6a12537ea25c0cb40b5916abb50df3f",
+  "checksum": "33f938e1a2c12be1faf7eb8c1f3e61ce98ca355ebfafe32d1db2dd59e84c215f",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -419,10 +419,6 @@
             {
               "id": "cfg-if 1.0.0",
               "target": "cfg_if"
-            },
-            {
-              "id": "getrandom 0.1.16",
-              "target": "build_script_build"
             }
           ],
           "selects": {
@@ -439,6 +435,12 @@
               }
             ]
           }
+        },
+        "extra_deps": {
+          "common": [
+            ":build_script_build"
+          ],
+          "selects": {}
         },
         "edition": "2018",
         "version": "0.1.16"
@@ -550,12 +552,9 @@
         "compile_data_glob": [
           "**"
         ],
-        "deps": {
+        "extra_deps": {
           "common": [
-            {
-              "id": "libc 0.2.139",
-              "target": "build_script_build"
-            }
+            ":build_script_build"
           ],
           "selects": {}
         },
@@ -596,6 +595,11 @@
             {
               "id": "clap 2.34.0",
               "target": "clap"
+            },
+            {
+              "id": "printer 0.1.0",
+              "target": "printer",
+              "workspace_member": true
             }
           ],
           "selects": {}
@@ -682,6 +686,11 @@
             {
               "id": "ferris-says 0.2.1",
               "target": "ferris_says"
+            },
+            {
+              "id": "rng 0.1.0",
+              "target": "rng",
+              "workspace_member": true
             }
           ],
           "selects": {}
@@ -1408,12 +1417,7 @@
           "selects": {}
         },
         "deps": {
-          "common": [
-            {
-              "id": "winapi 0.3.9",
-              "target": "build_script_build"
-            }
-          ],
+          "common": [],
           "selects": {
             "i686-pc-windows-gnu": [
               {
@@ -1428,6 +1432,12 @@
               }
             ]
           }
+        },
+        "extra_deps": {
+          "common": [
+            ":build_script_build"
+          ],
+          "selects": {}
         },
         "edition": "2015",
         "version": "0.3.9"
@@ -1491,12 +1501,9 @@
         "compile_data_glob": [
           "**"
         ],
-        "deps": {
+        "extra_deps": {
           "common": [
-            {
-              "id": "winapi-i686-pc-windows-gnu 0.4.0",
-              "target": "build_script_build"
-            }
+            ":build_script_build"
           ],
           "selects": {}
         },
@@ -1562,12 +1569,9 @@
         "compile_data_glob": [
           "**"
         ],
-        "deps": {
+        "extra_deps": {
           "common": [
-            {
-              "id": "winapi-x86_64-pc-windows-gnu 0.4.0",
-              "target": "build_script_build"
-            }
+            ":build_script_build"
           ],
           "selects": {}
         },

--- a/crate_universe/tests/integration/cargo_workspace/printer/BUILD.bazel
+++ b/crate_universe/tests/integration/cargo_workspace/printer/BUILD.bazel
@@ -7,9 +7,7 @@ rust_library(
     name = "printer",
     srcs = ["src/lib.rs"],
     edition = "2018",
-    deps = [
-        "//rng",
-    ] + all_crate_deps(),
+    deps = all_crate_deps(first_party = True),
 )
 
 rust_test(


### PR DESCRIPTION
Supersedes https://github.com/bazelbuild/rules_rust/pull/3308. Fixes https://github.com/bazelbuild/rules_rust/issues/1923

`crates_universe` drops dependency edges between crates of the same Cargo workspace, leaving users to restate them by hand in BUILD files while Cargo.toml already describes them.

Track those edges instead of discarding them, and render them into their own `_FIRST_PARTY_*` maps that `all_crate_deps(first_party = True)` opts into. The choice is per target at load time rather than per repository at generation time, so enabling it needs no repin and no configuration.

The Bazel repository holding the workspace's crates is derived from the rule's existing `cargo_lockfile` label, so there is no new user-facing attribute. That label stays out of the lockfile digest for the same reason `label_injection_mapping` does: canonical repository names are consumer-specific, and hashing one would demand a producer-side repin that a read-only bzlmod cache cannot perform.

Third-party output is unaffected. Rendering the test fixtures before and after this change produces a diff of pure additions: the new `first_party` parameter, its docstring, and six empty map literals for workspaces without intra-workspace dependencies.


Almost all written with AI, starting with #3308 as a base. I have manually reviewed the code.