### PR TITLE
Fix clang-cl paths in Cargo build script flags

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -217,11 +217,11 @@ def _pwd_flags_fsanitize_ignorelist(args):
 
 def _pwd_flags_isystem(args):
     """Prefix execroot-relative paths in -isystem-like arguments with ${pwd}."""
-    return _prefix_pwd_to_flag(args, ["-isystem", "-isystem-after", "-internal-isystem", "-cxx-isystem", "-stdlib++-isystem"])
+    return _prefix_pwd_to_flag(args, ["-isystem", "-isystem-after", "-internal-isystem", "-cxx-isystem", "-stdlib++-isystem", "/imsvc"])
 
 def _pwd_flags_L(args):
     """Prefix execroot-relative paths in -L arguments with ${pwd}."""
-    return _prefix_pwd_to_flag(args, ["-LIBPATH=", "-LIBPATH:", "-LIBPATH", "-L"])
+    return _prefix_pwd_to_flag(args, ["-LIBPATH=", "-LIBPATH:", "-LIBPATH", "/LIBPATH:", "/LIBPATH", "-L"])
 
 def _pwd_flags_B(args):
     """Prefix execroot-relative paths in -B arguments with ${pwd}."""
@@ -242,6 +242,10 @@ def _pwd_flags_resource_dir(args):
 def _pwd_flags_imacros(args):
     """Prefix execroot-relative paths in -imacros arguments with ${pwd}."""
     return _prefix_pwd_to_flag(args, ["-imacros"])
+
+def _pwd_flags_vfsoverlay(args):
+    """Prefix execroot-relative paths in VFS overlay arguments with ${pwd}."""
+    return _prefix_pwd_to_flag(args, ["-ivfsoverlay", "-vfsoverlay=", "-vfsoverlay", "/vfsoverlay:", "/vfsoverlay"])
 
 _DIRECT_LIB_EXTENSIONS = (".a", ".o", ".so", ".dylib")
 
@@ -283,13 +287,19 @@ _PWD_FLAG_PASSES = [
     _pwd_flags_isystem,
     _pwd_flags_fsanitize_ignorelist,
     _pwd_flags_imacros,
+    _pwd_flags_vfsoverlay,
     _pwd_flags_direct_libs,
 ]
 
 def _pwd_flags(args):
+    clang_cl_prefix = "/clang:"
+    clang_cl_wrapped = [arg.startswith(clang_cl_prefix) for arg in args]
+    args = [arg[len(clang_cl_prefix):] if clang_cl_wrapped[i] else arg for i, arg in enumerate(args)]
+
     for pwd_flags_pass in _PWD_FLAG_PASSES:
         args = pwd_flags_pass(args)
-    return args
+
+    return [clang_cl_prefix + arg if clang_cl_wrapped[i] else arg for i, arg in enumerate(args)]
 
 def _feature_enabled(ctx, feature_name, default = False):
     """Check if a feature is enabled.

--- a/cargo/tests/cargo_build_script/cc_args_and_env/BUILD.bazel
+++ b/cargo/tests/cargo_build_script/cc_args_and_env/BUILD.bazel
@@ -3,6 +3,8 @@ load(
     "bindir_absolute_test",
     "bindir_malformed_missing_value_test",
     "bindir_relative_test",
+    "clang_cl_paths_absolute_test",
+    "clang_cl_paths_relative_test",
     "direct_libs_absolute_test",
     "direct_libs_as_flag_operand_test",
     "direct_libs_relative_test",
@@ -53,6 +55,10 @@ bindir_relative_test(name = "bindir_relative_test")
 bindir_absolute_test(name = "bindir_absolute_test")
 
 bindir_malformed_missing_value_test(name = "bindir_malformed_missing_value_test")
+
+clang_cl_paths_relative_test(name = "clang_cl_paths_relative_test")
+
+clang_cl_paths_absolute_test(name = "clang_cl_paths_absolute_test")
 
 fsanitize_ignorelist_absolute_test(name = "fsanitize_ignorelist_absolute_test")
 

--- a/cargo/tests/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/cargo/tests/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -441,6 +441,62 @@ def xclang_isystem_absolute_test(name):
         expected_cflags = ["-Xclang", "-internal-isystem", "-Xclang", "/test/absolute/path"],
     )
 
+def clang_cl_paths_relative_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = [
+            "/imsvctest/relative/include",
+            "/imsvc",
+            "test/relative/include2",
+            "/clang:-isystem",
+            "/clang:test/relative/include3",
+            "/clang:-resource-dir=test/relative/resources",
+            "/clang:-ivfsoverlay",
+            "/clang:test/relative/headers.yaml",
+            "/clang:/vfsoverlay:test/relative/libraries.yaml",
+            "/clang:/LIBPATH:test/relative/lib",
+        ],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = [
+            "/imsvc${pwd}/test/relative/include",
+            "/imsvc",
+            "${pwd}/test/relative/include2",
+            "/clang:-isystem",
+            "/clang:${pwd}/test/relative/include3",
+            "/clang:-resource-dir=${pwd}/test/relative/resources",
+            "/clang:-ivfsoverlay",
+            "/clang:${pwd}/test/relative/headers.yaml",
+            "/clang:/vfsoverlay:${pwd}/test/relative/libraries.yaml",
+            "/clang:/LIBPATH:${pwd}/test/relative/lib",
+        ],
+    )
+
+def clang_cl_paths_absolute_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = [
+            "/imsvc/test/absolute/include",
+            "/clang:-ivfsoverlay",
+            "/clang:/test/absolute/headers.yaml",
+            "/clang:/vfsoverlay:/test/absolute/libraries.yaml",
+            "/clang:/LIBPATH:/test/absolute/lib",
+        ],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = [
+            "/imsvc/test/absolute/include",
+            "/clang:-ivfsoverlay",
+            "/clang:/test/absolute/headers.yaml",
+            "/clang:/vfsoverlay:/test/absolute/libraries.yaml",
+            "/clang:/LIBPATH:/test/absolute/lib",
+        ],
+    )
+
 def isystem_relative_test(name):
     cargo_build_script_with_extra_cc_compile_flags(
         name = "%s/cargo_build_script" % name,


### PR DESCRIPTION
Upstream of what was required to build codex-cli for Windows MSVC using windows_support and hermetic-llvm new hermetic Windows MSVC hermetic cross link env.

## Summary

- rewrite execroot-relative clang-cl `/imsvc` and slash `/LIBPATH` paths exported to Cargo build scripts
- rewrite VFS overlay paths, including arguments forwarded through clang-cl's `/clang:` wrapper
- preserve absolute paths and restore `/clang:` after applying the existing path-rewrite passes

## Motivation

`cargo_build_script` runs build scripts from their manifest directory, while C/C++ toolchain arguments are commonly relative to Bazel's execroot. `rules_rust` already prefixes recognized relative paths with `${pwd}`, which the build-script runner expands to the execroot.

clang-cl toolchains can express the same inputs with `/imsvc`, `/LIBPATH`, VFS-overlay flags, and `/clang:`-forwarded arguments. Those spellings bypassed the existing passes, leaving paths relative to the wrong working directory.

This was reproduced while cross-compiling the real `openai/codex` CLI to `x86_64-pc-windows-msvc` with Linux remote execution. A `tree-sitter` Cargo build script received execroot-relative `/imsvc` and `/clang:-ivfsoverlay` arguments and clang-cl could not open the overlay.

Assisted-by: OpenAI Codex. The contributor reviewed and owns the submitted change.
